### PR TITLE
Fix: Remove Russian language definition

### DIFF
--- a/module.json
+++ b/module.json
@@ -33,11 +33,6 @@
 			"path": "./lang/en.json"
 		},
 		{
-			"lang": "ru",
-			"name": "Русский (Russian)",
-			"path": "./lang/ru.json"
-		},
-		{
 			"lang": "ko",
 			"name": "한국어 (Korean)",
 			"path": "./lang/ko.json"


### PR DESCRIPTION
It causes a warning on startup since there is no longer a file with the name ru.json in the lang directory.

The warning is as follows: [warn] The healthEstimate Language definition Русский (Russian) does not exist
![image](https://user-images.githubusercontent.com/82790112/116950283-84c91b00-ac52-11eb-9b1c-9b11b2d0a050.png)

This fixes the issue.