### PR TITLE
Support lancer 0.9.x

### DIFF
--- a/module/systems/lancer.js
+++ b/module/systems/lancer.js
@@ -2,7 +2,7 @@ import {t} from '../utils.js';
 
 const fraction = (token) => {
 	const data = token.actor.data;
-	const hp   = data.type === 'deployable' ? data.data.hp : data.data.mech.hp;
+	const hp   = data.data.derived.current_hp;
 	return hp.value / hp.max;
 };
 


### PR DESCRIPTION
Thanks for this great module!!

The beta version of lancer 0.9.x which supports Foundry 0.8.x handles HP more conveniently for deployables and characters. This gets me working health estimates (so far as I could tell) for both deployables and characters running on [0.9.4](https://github.com/Eranziel/foundryvtt-lancer/tree/beta-release)

(This version of lancer isn't officially released yet, but I leave this fix here as ready to be merged when that comes out, barring major changes or other goofs on my end)

- [ ] wait for 0.9.x to hit master before merging, probably