### PR TITLE
[SWADE] NPCs with 0 max wounds show estimation

### DIFF
--- a/module/systems/swade.js
+++ b/module/systems/swade.js
@@ -1,6 +1,8 @@
 const fraction = function (token) {
 	const hp = token.actor.data.data.wounds;
-	return (hp.max - hp.value) / hp.max;
+	let frac = (hp.max - hp.value) / hp.max;
+	if (isNaN(frac)) { frac = 1 }
+	return frac
 };
 
 export { fraction };


### PR DESCRIPTION
In SWADE it is very common to have NPCs with 0 max wounds (wounds can be compared to HP but reversed (more wounds is less HP)). The problem is however, that HE does not show the estimation above the token when the actor has 0 max Wounds. This lets players know immediately, that they are dealing with an actor that has 0 max wounds (which is bad because NPCs can have more that 0 max wounds).
Changing the swade.js to this seems to work for me but I haven't looked at the full code so I can't really tell if this has the potential to break anything. In my limited testing it seems to work fine though.