### PR TITLE
CoC7 system - Don't show health estimate for containers

### DIFF
--- a/module/systems/CoC7.js
+++ b/module/systems/CoC7.js
@@ -6,4 +6,7 @@ const fraction = function (token) {
 	return 0;
 };
 
-export { fraction };
+const breakCondition = `
+	|| token.actor.data.type === 'container'`;
+
+export { fraction, breakCondition };


### PR DESCRIPTION
Call of Cthulhu 7th edition (Unofficial) is adding support for containers which don't have health.