### PR TITLE
Add Splittermond as a supported system

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -17,7 +17,7 @@
 			},
 			"isNow": "ist jetzt",
 			"showDescription": {
-				"name": "Zeige SChätzung: Benutzer",
+				"name": "Zeige Schätzung: Benutzer",
 				"hint": "Zeige die Schätzungen der folgenden Benutzer.",
 				"choices": {
 					"all": "Alle",
@@ -156,7 +156,7 @@
 		},
 		"worldbuilding": {
 			"simpleRule": {
-				"name": "SChätzungs-Regel",
+				"name": "Schätzungs-Regel",
 				"hint": "Die JS-Formel für die Berechnung der Token-Schätzung. Verändere sie mit Vorsicht! Standardmäßig wird eine abnehmende Gesundheit angenommen, bspw. startest du mit 10/10 HP und gehst bis 0/10 HP herunter, sobald du Schaden nimmst.",
 				"default": "const hp = token.actor.data.data.health; return hp.value / hp.max"
 			}

--- a/module/systemSpecifics.js
+++ b/module/systemSpecifics.js
@@ -92,7 +92,7 @@ export function prepareSystemSpecifics() {
 			"age-system", "alienrpg", "archmage", "band-of-blades", "blades-in-the-dark", "CoC7", "cyberpunk-red-core",
 			"D35E", "dnd5e", "ds4", "dsa5", "dungeonworld", "fate", , "foundryvtt-reve-de-dragon",
 			"lancer", "monsterweek", "numenera", "ose", "od6s", "pbta", "pf1", "pf2e", "ryuutama",
-			"scum-and-villainy", "shadowrun5e", "starfinder", "starwarsffg", "sw5e", "swade", "symbaroum",
+			"scum-and-villainy", "shadowrun5e", "splittermond", "starfinder", "starwarsffg", "sw5e", "swade", "symbaroum",
 			"tormenta20", "trpg", "twodsix", "uesrpg-d100", "wfrp4e", "worldbuilding"
 		];
 		let importString = systems.includes(game.system.id) ? `./systems/${game.system.id}.js` : `./systems/generic.js`;

--- a/module/systems/splittermond.js
+++ b/module/systems/splittermond.js
@@ -1,0 +1,7 @@
+const fraction = function (token) {
+	const hp = token.actor.data.data.health;
+
+    return (hp.max - hp.total.value) / hp.max;
+};
+
+export { fraction };

--- a/module/systems/splittermond.js
+++ b/module/systems/splittermond.js
@@ -1,7 +1,7 @@
 const fraction = function (token) {
 	const hp = token.actor.data.data.health;
 
-    return (hp.max - hp.total.value) / hp.max;
+    return hp.total.value / hp.max;
 };
 
 export { fraction };


### PR DESCRIPTION
Greetings,
Splittermond is a german roleplaying game which uses a quite complicated way to calculate health. But it can be simplified by just using hp.total.value instead of the more common hp.value.

It could be made better to represent all rules from splittermond, but since it's such a niche system I don't think it's worth it. It uses stun damage on top of normal health and temporary health. Additionally it uses a wound system, which can have 1, 3 or 5 levels of wounds depending on the character. Each level with it's own official name and a death mechanic that either triggers when HP reach 0 or you get damage on your last wound level, unless you only have a single level in total... well, this PR works, too, I guess :D

With this little change it should be working as expected for "generic" systems. If there is a better way without adding it as a supported system let me know.