### PR TITLE
pull only fontFamily from CONFIG.canvasTextStyle

### DIFF
--- a/module/logic.js
+++ b/module/logic.js
@@ -97,14 +97,13 @@ export class HealthEstimate {
 
 			const userTextStyle = {
 				fontSize: fontSize,
+				fontFamily: CONFIG.canvasTextStyle.fontFamily,
 				fill: color,
 				stroke: stroke,
 				strokeThickness: 3,
 				padding: 5,
 			};
-			token.healthEstimate = token.addChild(
-				new PIXI.Text(desc, mergeObject(CONFIG.canvasTextStyle, userTextStyle))
-			);
+			token.healthEstimate = token.addChild(new PIXI.Text(desc, userTextStyle));
 
 			token.healthEstimate.anchor.x = 0.5;
 			if (!this.scaleToZoom || (this.scaleToZoom && zoomLevel >= 1)) {


### PR DESCRIPTION
After doing some testing, it seems my pr had some issues which caused `userTextStyle`'s settings to actually override the `canvasTextStyle`. This pr fixes things so that doesn't happen, as I'm now only taking the fontFamily, not the styleID (Surprise! I did not realize this was a thing). My apologies, and thanks again for this great module.