### PR TITLE
Better health estimate for cyphersystem (with user settings)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -181,6 +181,16 @@
 				"hint": "Ignores the Stages setting and uses the Cyberpunk RED Core's wound states."
 			}
 		},
+		"cyphersystem": {
+			"impaired": {
+				"name": "Health level for Impaired PCs",
+				"hint": "Sets the maximum health level (current / maximum, fraction 0.0 - 1.0) that can be reported for a PC that is Impaired on the Death Track"
+			},
+			"debilitated": {
+				"name": "Health level for Debilitated PCs",
+				"hint": "Sets the maximum health level (current / maximum, fraction 0.0 - 1.0) that can be reported for a PC that is Debilitated on the Death Track"
+			}
+		},
 		"dnd5e": {
 			"vehicleNames": {
 				"hint": "Descriptions shown for vehicles.",

--- a/module/systems/cyphersystem.js
+++ b/module/systems/cyphersystem.js
@@ -35,6 +35,7 @@ const fraction = function (token) {
     }
 };
 
+// New module configuration settings specific to this module
 const settings = () => {
 	return {
 		"cyphersystem.impaired": {
@@ -48,4 +49,7 @@ const settings = () => {
 	};
 };
 
-export { fraction, settings };
+// Only show Health Estimate on the following Actor types
+const breakCondition = `|| ![ 'pc', 'npc', 'companion','community' ].includes(token.actor.type)`;
+
+export { fraction, settings, breakCondition };

--- a/module/systems/cyphersystem.js
+++ b/module/systems/cyphersystem.js
@@ -1,31 +1,51 @@
 const fraction = function (token) {
     const actor = token.actor;
     if (actor.type === 'pc') {
+        const pools = actor.system.pools;
+        let curr = pools.might.value + pools.speed.value + pools.intellect.value;
+        let max  = pools.might.max   + pools.speed.max   + pools.intellect.max;
+        // TODO: should we ever include the additional pool in this calculation?
+        if (actor.system.settings.general.additionalPool.active) {
+            curr += pools.additional.value;
+            max  += pools.additional.max;
+        }
+        if (curr > max) curr = max;
+        let result = curr / max;
+        let limit = 1.0;
+
         switch (actor.system.combat.damageTrack.state) {
             case 'Hale':
-                {
-                    const pools = actor.system.pools;
-                    let curr = pools.might.value + pools.speed.value + pools.intellect.value;
-                    let max  = pools.might.max   + pools.speed.max   + pools.intellect.max;
-                    // TODO: should we ever include the additional pool in this calculation?
-                    if (actor.system.settings.general.additionalPool.active) {
-                        curr += pools.additional.value;
-                        max  += pools.additional.max;
-                    }
-                    if (curr > max) curr = max;
-                    return curr / max;
-                }
+                break;
             case 'Impaired':
-                return 0.66;
+                limit = game.settings.get('healthEstimate', "cyphersystem.impaired");
+                break;
             case 'Debilitated':
-                return 0.33;
+                limit = game.settings.get('healthEstimate', "cyphersystem.debilitated");
+                break;
             default:
-                return 0;
+                result = 0.0;
         }
-    } else {
+        if (result > limit) result = limit;
+        return result;
+    } else if (actor.system.pools?.health) {
         let hp = actor.system.pools.health;
         return hp.value / hp.max;
+    } else {
+        return ;
     }
 };
 
-export { fraction };
+const settings = () => {
+	return {
+		"cyphersystem.impaired": {
+			type: Number,
+			default: 0.5,
+		},
+		"cyphersystem.debilitated": {
+			type: Number,
+			default: 0.1,
+		},
+	};
+};
+
+export { fraction, settings };


### PR DESCRIPTION
I apologise for the update so soon after the initial submission, but some feedback has indicated a better range for the health estimates for cyphersystem.
It includes a bug fix for certain types of Actors, and two new module settings.