### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/fi.json
+++ b/lang/fi.json
@@ -121,6 +121,23 @@
 				"positionAdjustment": {
 					"name": "Sijainnin säätö"
 				}
+			},
+			"estimates": {
+				"best": "Paras",
+				"states": {
+					"0": "Tajuton",
+					"1": "Lähellä kuolemaa",
+					"2": "Pahasti loukkaantunut",
+					"3": "Loukkaantunut",
+					"4": "Lievästi loukkaantunut",
+					"5": "Täysikuntoinen"
+				},
+				"vehicles": {
+					"0": "Romuttunut",
+					"1": "Liekeissä",
+					"2": "Savuttaa"
+				},
+				"worst": "Huonoin"
 			}
 		}
 	}

--- a/lang/fi.json
+++ b/lang/fi.json
@@ -16,15 +16,15 @@
 				},
 				"dontMarkDead": {
 					"name": "Älä merkitse kuolleeksi",
-					"hint": "Ei merkitse EPH:ja kuolleiksi, kun niiden KP:t ovat 0 (esim. se näkyy tajuttomana). Tämä on hyödyllinen vain, jos käytät asetusta \"EPH:t kuolevat välittömästi\"."
+					"hint": "Ei merkitse EPH:ja kuolleiksi, kun niiden KP:t ovat 0 (esim. se näkyy tajuttomana). Tämä on hyödyllinen vain, jos käytät asetusta \"{setting}\"."
 				},
 				"hideEstimates": {
 					"name": "Piilota arviot",
-					"hint": "Piilottaa valittujen pelinappuloiden arviot pelaajilta. Piilotetut arviot näyttävät PJ:lle *-merkin."
+					"hint": "Piilottaa valittujen pelinappuloiden arviot pelaajilta. Piilotettuja arvioita ei lähetetä keskusteluun, jos asetus on päällä, ja ne näytetään tähdellä (*) PJ:lle."
 				},
 				"hideNames": {
 					"name": "Piilota nimet",
-					"hint": "Piilottaa valittujen pelinappuloiden nimet, kun käytät asetusta \"Tulosta arvio keskusteluun\"."
+					"hint": "Piilottaa valittujen pelinappuloiden nimet, kun käytät asetusta \"{setting}\"."
 				},
 				"hideEstimatesAndNames": {
 					"name": "Piilota arviot ja nimet",
@@ -45,11 +45,11 @@
 					}
 				}
 			},
-			"isNow": "on nyt",
+			"isNow": "{name} on nyt {desc}.",
 			"unknownEntity": {
 				"default": "Tuntematon entiteetti",
 				"name": "Tuntemattoman entiteetin nimi",
-				"hint": "Asettaa, miten piilotettua hahmoa kutsutaan."
+				"hint": "Asettaa, miten piilotettua hahmoa kutsutaan.{warning}"
 			},
 			"alwaysShow": {
 				"name": "Näytä arviot aina",
@@ -78,14 +78,14 @@
 			"deathStateName": {
 				"default": "Kuollut",
 				"name": "Kuollut-tilan nimi",
-				"hint": "Pelaajille näytettävä kuvaus kun pelinappula on kuollut. Hakemisto-välilehdellä on makro, jolla merkitään yksi tai useampi pelinappula kuolleeksi."
+				"hint": "Kuvaus, joka näytetään, kun pelinappula on kuollut."
 			},
 			"deathMarker": {
 				"name": "Kuolleen merkki"
 			},
 			"NPCsJustDie": {
 				"name": "EPH:t kuolevat välittömästi",
-				"hint": "EPH:jen viimeinen vaihe korvataan kuollut-tilan nimellä."
+				"hint": "Niiden pelinappuloiden viimeinen vaihe, joiden hahmoja pelaajat eivät ole valinneet, korvataan asetuksella \"{setting}\". Lisätietoja siitä, mitä \"pelaajien valitsemat\" tarkoittaa, on Foundryn Käyttäjät ja käyttöoikeudet -artikkelin Käyttäjämääritykset-osiossa."
 			},
 			"perfectionism": {
 				"name": "Käyttäytyminen",
@@ -98,7 +98,7 @@
 			},
 			"outputChat": {
 				"name": "Tulosta arvio keskusteluun",
-				"hint": "Tulosta kaikki arvion muutokset keskusteluun. Piilota arvio -makrolla merkityt hahmot näytetään \"Tuntematon entiteetti\" tekstillä."
+				"hint": "Tulosta kaikki arviomuutokset keskusteluun. Piilota nimet -asetuksella merkityt pelinappulat näytetään asetuksen {asetus} kuvauksena."
 			},
 			"addTemp": {
 				"name": "Lisää tilapäiset kestopisteet"
@@ -119,7 +119,7 @@
 					"bottom": "Alhaalla"
 				},
 				"positionAdjustment": {
-					"name": "Sijainnin säätö"
+					"name": "Reunan säätö"
 				}
 			},
 			"estimates": {
@@ -138,6 +138,19 @@
 					"2": "Savuttaa"
 				},
 				"worst": "Huonoin"
+			},
+			"breakOnZeroMaxHP": {
+				"hint": "Hyödyllinen kappaleille, joissa on pelinappuloita."
+			}
+		},
+		"swade": {
+			"showIncap": {
+				"hint": "Pelinappulat, joissa on {incap} tilatehoste näytetään \"{incap}\" niiden nykyisen arvion sijaan. Ei toimi pelinappuloille, jotka ovat ajoneuvoja tai kuolleita."
+			}
+		},
+		"custom-system-builder": {
+			"FractionHP": {
+				"hint": "Tämä on todennäköisesti {dataPath1} tai {dataPath2}."
 			}
 		}
 	}

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -300,6 +300,12 @@
 			"useSystemStates": {
 				"name": "Utilise les états de blessure",
 				"hint": "Ignore les réglages des stades et utilise les états de blessure du jeu Cyberpunk Red."
+			},
+			"unorganics": {
+				"2": "Dysfonctionnement",
+				"0": "Désactivé",
+				"4": "Intact",
+				"3": "Opérationnel"
 			}
 		},
 		"PF2E": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -302,7 +302,7 @@
 				"hint": "Ignore les réglages des stades et utilise les états de blessure du jeu Cyberpunk Red."
 			},
 			"unorganics": {
-				"2": "Dysfonctionnement",
+				"2": "Dysfonctionnant",
 				"0": "Désactivé",
 				"4": "Intact",
 				"3": "Opérationnel"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -214,6 +214,12 @@
 			"useSystemStates": {
 				"name": "Usar Estágios de Ferimento",
 				"hint": "Ignora a configuração de Estágios e usa os estágios de ferimentos do Cyberpunk RED Core."
+			},
+			"unorganics": {
+				"3": "Operacional",
+				"2": "Defeituoso",
+				"4": "Intacto",
+				"0": "Desabilitado"
 			}
 		},
 		"dnd5e": {


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Health Estimate/main](https://weblate.foundryvtt-hub.com/projects/healthEstimate/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/healthEstimate/-/main/horizontal-auto.svg)