### PR TITLE
Prevent multiple chat messages if multiple GMs are logged in

### DIFF
--- a/lib/HealthMonitor.js
+++ b/lib/HealthMonitor.js
@@ -75,6 +75,9 @@ export function outputStageChange(token) {
 		name = sGet("core.unknownEntity");
 	}
 	const css = index > oldStage.index ? "<span class='hm_messageheal'>" : "<span class='hm_messagetaken'>";
+
+	// Prevent multi post of chat message if multiple GMs are logged in
+	if ( !game.users.activeGM?.isSelf ) return;
 	// Output change if label isn't empty and is different from the last, for the case where
 	// the same stage is used for different fractions e.g. "Unconscious, Bloodied, Hurt, Hurt, Injured"
 	if (estimate.label && estimate.label != oldStage.estimate.label) {


### PR DESCRIPTION
Hi,

first of all. Thanks for this nice module.

Now to the problem:
You get multiple chat notifications, if multiple GM's are logged in a world and the option for estimations in the chat is enabled.

The added change only executes the chat message for one GM, and avoids multiple posts of the same message.


If you want to reproduce the problem:
* Create to GMs in a world.
* Log in with both (e.g. two browsers)
* Enable the chat estimation
* Cause a chat estimation


Regards