### PR TITLE
Starfinder NPCs and drones should not add stamina to calculate health

### DIFF
--- a/module/EstimationProvider.js
+++ b/module/EstimationProvider.js
@@ -1188,12 +1188,16 @@ export class sfrpgEstimationProvider extends EstimationProvider {
 		switch (type) {
 			case "npc":
 			case "npc2":
-			case "drone":
-			case "character":
+			case "drone": {
+				const temp = sGet("core.addTemp") ? hp.temp ?? 0 : 0;
+				return Math.min((hp.value + temp) / hp.max, 1);				
+			}
+			case "character": {
 				const sp = token.actor.system.attributes.sp;
 				const addStamina = sGet("starfinder.addStamina") ? 1 : 0;
 				const temp = sGet("core.addTemp") ? hp.temp ?? 0 : 0;
 				return Math.min((hp.value + sp.value * addStamina + temp) / (hp.max + sp.max * addStamina), 1);
+			}
 			case "vehicle":
 				if (sGet("starfinder.useThreshold")) {
 					if (hp.value > hp.threshold) return 1;


### PR DESCRIPTION
Currently healthEstimate tries to calculate the health of NPCs, drones, and player characters by taking stamina into account.  However, NPCs and drones don't have a stamina stat. 

In the case of NPCs this causes an error and no health estimate to be shown (see #186). This is because the actor representing the NPC has no `sp` attribute at all. This causes an error [when trying to access `sp` from the token](https://github.com/mclemente/healthEstimate/blob/851b2d6b2071beaa97c2fd0bd3e0154414320759/module/EstimationProvider.js#L1193). 

 In the case of drones, this causes a lower estimate than actual health (see #187).  This happens because [when the `sp` attribute of the drone is retrieved](https://github.com/mclemente/healthEstimate/blob/851b2d6b2071beaa97c2fd0bd3e0154414320759/module/EstimationProvider.js#L1193), it returns a structure that has `max` set to `10` (incorrectly) and `value` set to `0` (correctly).
 
 Both problems can be solved by excluding stamina points from this calculation altogether, which is what this PR does.
 
Fixes #186
Fixes #187