### PR TITLE
Shadowrun 5E Estimation Provider Fix

### DIFF
--- a/module/EstimationProvider.js
+++ b/module/EstimationProvider.js
@@ -1256,9 +1256,26 @@ export class sfrpgEstimationProvider extends EstimationProvider {
 
 export class shadowrun5eEstimationProvider extends EstimationProvider {
 	fraction(token) {
-		const stun = token.actor.system.track.stun;
-		const physical = token.actor.system.track.physical;
-		return Math.min((stun.max - stun.value) / stun.max, (physical.max - physical.value) / physical.max);
+		var stun;
+		var physical;
+		var matrix;
+		switch (token.actor.type) {	
+			case 'character':
+				stun = token.actor.system.track.stun;
+				physical = token.actor.system.track.physical;
+				return Math.min((stun.max - stun.value) / stun.max, (physical.max - physical.value) / physical.max);
+			case 'vehicle':
+				physical = token.actor.system.track.physical;
+				return (physical.max - physical.value) / physical.max;
+			case 'sprite':
+				matrix =  token.actor.system.matrix.condition_monitor;
+				return (matrix.max - matrix.value) / matrix.max;
+			case 'spirit':
+				stun = token.actor.system.track.stun;
+				physical = token.actor.system.track.physical;
+				return Math.min((stun.max - stun.value) / stun.max, (physical.max - physical.value) / physical.max);
+		}
+		
 	}
 }
 


### PR DESCRIPTION
Fixed Shadowrun5e Estimation provide by adding vehicles and sprite support, as they lack stun and physical tracks, as the module provides an error when hovering over a vehicle or sprite, since they lack those tracks