### PR TITLE
Fix Hit Points Attribute Data Path setting being ignored when a token has zero HP (#212)

### DIFF
--- a/src/module/providers/templates/Generic.js
+++ b/src/module/providers/templates/Generic.js
@@ -11,10 +11,10 @@ export default class GenericEstimationProvider extends EstimationProvider {
 	fraction(token) {
 		const hpPath = sGet("core.custom.FractionHP");
 		let hp = (hpPath && getNestedData(token, hpPath))
-			|| (game.system.primaryTokenAttribute
+			?? (game.system.primaryTokenAttribute
 				&& getNestedData(token, `actor.system.${game.system.primaryTokenAttribute}`))
-			|| token.actor.system.attributes?.hp
-			|| token.actor.system.hp;
+			?? token.actor.system.attributes?.hp
+			?? token.actor.system.hp;
 		let temp = 0;
 		if (sGet("core.addTemp")) temp = Number(hp?.temp) || 0;
 


### PR DESCRIPTION
Replaces the OR operator with the nullish coalescing (??) operator to ensure that fallbacks are only evaluated if a given value is `null` or `undefined`.

Fixes #212.