### PR TITLE
Draw Steel Support

### DIFF
--- a/src/module/providers/_module.js
+++ b/src/module/providers/_module.js
@@ -14,6 +14,7 @@ export { default as D35EEstimationProvider } from "./D35E.js";
 export { default as daggerheartEstimationProvider } from "./daggerheart.js";
 export { default as dnd4eEstimationProvider } from "./dnd4e.js";
 export { default as dnd5eEstimationProvider } from "./dnd5e.js";
+export { default as drawsteelEstimationProvider } from "./draw-steel.js";
 export { default as ds4EstimationProvider } from "./ds4.js";
 export { default as dsa5EstimationProvider } from "./dsa5.js";
 export { default as dungeonworldEstimationProvider } from "./dungeonworld.js";

--- a/src/module/providers/_shared.js
+++ b/src/module/providers/_shared.js
@@ -11,5 +11,6 @@ export const providerKeys = {
 	"foundryvtt-reve-de-dragon": "reveDeDragon",
 	"scum-and-villainy": "scumAndVillainy",
 	"uesrpg-d100": "uesrpg",
-	"wrath-and-glory": "wrathAndGlory"
+	"wrath-and-glory": "wrathAndGlory",
+	"draw-steel": "drawsteel",
 };

--- a/src/module/providers/draw-steel.js
+++ b/src/module/providers/draw-steel.js
@@ -42,7 +42,6 @@ export default class drawsteelEstimationProvider extends EstimationProvider {
 		const maxHealth = token.actor.system.stamina.max;
 		const currentHealth = token.actor.system.stamina.value;
 
-		const fraction = (currentHealth - minHealth) / (maxHealth - minHealth);
-		return Math.max(0, Math.min(1, fraction)); // clamp between 0–1
+		return (currentHealth - minHealth) / (maxHealth - minHealth);
 	}
 }

--- a/src/module/providers/draw-steel.js
+++ b/src/module/providers/draw-steel.js
@@ -1,0 +1,48 @@
+import EstimationProvider from "./templates/Base.js";
+
+export default class drawsteelEstimationProvider extends EstimationProvider {
+	constructor() {
+		super();
+		this.organicTypes = ["hero", "npc"];
+		this.breakOnZeroMaxHP = true;
+		this.estimations = [
+			{
+				name: "unconscious",
+				ignoreColor: true,
+				rule: "effects.values().some((x) => x.name === 'Unconscious' || x.name === 'Asleep');",
+				estimates: [{ value: 100, label: "Unconscious" }],
+			},
+			{
+				name: "Heroes",
+				rule: "token.actor.type === 'hero'",
+				estimates: [
+					{ value: 0, label: "Dead" },
+					{ value: 33, label: "Dying" },
+					{ value: 66, label: "Winded" },
+					{ value: 99, label: "Injured" },
+					{ value: 100, label: "Unharmed" },
+				],
+			},
+			{
+				name: "NPCs",
+				rule: "token.actor.type === 'npc'",
+				estimates: [
+					{ value: 0, label: "Dead" },
+					{ value: 25, label: "Near Death" },
+					{ value: 50, label: "Winded" },
+					{ value: 99, label: "Injured" },
+					{ value: 100, label: "Unharmed" },
+				],
+			},
+		];
+	}
+
+	fraction(token) {
+		const minHealth = token.actor.system.stamina.min;
+		const maxHealth = token.actor.system.stamina.max;
+		const currentHealth = token.actor.system.stamina.value;
+
+		const fraction = (currentHealth - minHealth) / (maxHealth - minHealth);
+		return Math.max(0, Math.min(1, fraction)); // clamp between 0–1
+	}
+}


### PR DESCRIPTION
Support for Draw Steel on FoundryVTT. 

In Draw Steel the players (heroes) can go into negative health values equal to half their max HP (called stamina). 
So, a hero with 40 max stamina can enter a "dying" state that runs up to -20 stamina. 
But it also still has to work for NPCs that simply die upon reaching 0 stamina and don't go into negatives. 

`const fraction = (currentHealth - minHealth) / (maxHealth - minHealth);`

<img width="1362" height="528" alt="image" src="https://github.com/user-attachments/assets/18e84ae6-ccab-40ff-b53c-6a4c6e29e1d5" />

