### PR TITLE
pf2e v14 bug fix

### DIFF
--- a/src/module/logic.js
+++ b/src/module/logic.js
@@ -465,7 +465,7 @@ export class HealthEstimate {
 	tokenEffectsPath(token) {
 		const deadIcon = this.estimationProvider.deathMarker.config
 			? this.deathMarker
-			: CONFIG.statusEffects.find((x) => x.id === "dead")?.img ?? this.deathMarker;
+			: (Array.isArray(CONFIG.statusEffects) ? CONFIG.statusEffects : Object.values(CONFIG.statusEffects)).find((x) => x.id === "dead")?.img ?? this.deathMarker;
 		return Array.from(token.actor.effects.values()).some((x) => x.img === deadIcon);
 	}
 

--- a/src/module/providers/swade.js
+++ b/src/module/providers/swade.js
@@ -58,7 +58,7 @@ export default class swadeEstimationProvider extends EstimationProvider {
 	}
 
 	tokenEffects(token) {
-		const incapIcon = CONFIG.statusEffects.find((effect) => effect.id === "incapacitated").img;
+		const incapIcon = (Array.isArray(CONFIG.statusEffects) ? CONFIG.statusEffects : Object.values(CONFIG.statusEffects)).find((effect) => effect.id === "incapacitated").img;
 		return !!token.actor.effects.find((e) => e.img === incapIcon);
 	}
 

--- a/src/module/providers/templates/Base.js
+++ b/src/module/providers/templates/Base.js
@@ -33,11 +33,11 @@ export default class EstimationProvider {
 		this.deathMarker = {
 			/** Sets if the setting will be visible in the module's settings */
 			config:
-				!CONFIG.statusEffects.find((x) => x.id === "dead")
+				!(Array.isArray(CONFIG.statusEffects) ? CONFIG.statusEffects : Object.values(CONFIG.statusEffects)).find((x) => x.id === "dead")
 				|| game.modules.get("combat-utility-belt")?.active
 				|| game.modules.get("condition-lab-triggler")?.active,
 			/** Sets the setting's default value */
-			default: CONFIG.statusEffects.find((x) => x.id === "dead")?.img || "icons/svg/skull.svg",
+			default: (Array.isArray(CONFIG.statusEffects) ? CONFIG.statusEffects : Object.values(CONFIG.statusEffects)).find((x) => x.id === "dead")?.img || "icons/svg/skull.svg",
 		};
 
 		/**


### PR DESCRIPTION
In the newest versions of pf2e (post v14 compatibility), `CONFIG.statusEffects` no longer returns an array but instead an object. This causes `CONFIG.statusEffects.find` to fail in 4 separate instances and Health Estimate to stop working for pf2e. 

I replaced all instances of `CONFIG.statusEffects` with `(Array.isArray(CONFIG.statusEffects) ? CONFIG.statusEffects : Object.values(CONFIG.statusEffects))`, making sure that we always have a workable array. Note, that the object entries appear to follow the same scheme as before the update, i.e. things like `id` and `img` are still present.

This is the easiest to solution i can think of to fix this problem for pf2e without risking compatibility with any other system. It might also fix other system compatibility issues down the line