### PR TITLE
Providers Refactor

### DIFF
--- a/src/module/HealthEstimate.js
+++ b/src/module/HealthEstimate.js
@@ -1,7 +1,7 @@
 import * as providers from "./providers/_module.js";
 import { providerKeys } from "./providers/_shared.js";
 import { registerSettings } from "./settings.js";
-import { addSetting, disableCheckbox, f, isEmpty, repositionTooltip, sGet, t } from "./utils.js";
+import { addSetting, disableCheckbox, f, repositionTooltip, sGet, t } from "./utils.js";
 
 export class HealthEstimate {
 	constructor() {
@@ -14,17 +14,15 @@ export class HealthEstimate {
 			?? "Generic";
 
 		/** @type {EstimateProvider} */
-		this.#estimationProvider = new providers[`${providerString}EstimationProvider`]();
+		this.provider = new providers[`${providerString}EstimationProvider`]();
 		registerSettings();
 
-		this.breakConditions.system = this.provider.breakCondition;
 		if (this.provider.tokenEffects !== undefined) {
 			this.tokenEffectsPath = this.provider.tokenEffects;
 		}
 		for (let [key, data] of Object.entries(this.provider.settings)) {
 			addSetting(key, data);
 		}
-		this.updateBreakConditions();
 		this.updateSettings();
 
 		CONFIG.queries["health-estimate-refreshTokens"] = () => {
@@ -58,8 +56,6 @@ export class HealthEstimate {
 		);
 	}
 
-	#estimationProvider;
-
 	/**
 	 * Caches estimates.
 	 * @type {{PIXI.Text}}
@@ -71,8 +67,6 @@ export class HealthEstimate {
 	 * @type {{SpriteMaterial}}
 	 */
 	_3DCache = {};
-
-	breakConditions = {};
 
 	settings = {};
 
@@ -94,14 +88,6 @@ export class HealthEstimate {
 	 */
 	get gridScale() {
 		return this.scaleToGridSize ? canvas.scene.dimensions.size / this.gridSize : 1;
-	}
-
-	/**
-	 * The module's Estimate Provider.
-	 * @type {EstimationProvider}
-	 */
-	get provider() {
-		return this.#estimationProvider;
 	}
 
 	/**
@@ -128,9 +114,14 @@ export class HealthEstimate {
 	_handleOverlay(token, hovered) {
 		if (
 			!token?.actor
-			|| this.breakOverlayRender(token)
-			|| (!game.user.isGM && this.hideEstimate(token))
 			|| this.settings.display === "disabled"
+			|| (!game.user.isGM && this.hideEstimate(token))
+			|| (this.settings.showDescription === 1 && !game.user.isGM)
+			|| (this.settings.showDescription === 2 && game.user.isGM)
+			|| (this.settings.showDescriptionTokenType === 1 && !token.actor?.hasPlayerOwner)
+			|| (this.settings.showDescriptionTokenType === 2 && token.actor?.hasPlayerOwner)
+			|| this.provider.filteredTypes.includes(token.actor.type)
+			|| this.provider.breakCondition(token)
 		) return;
 
 		// Create PIXI
@@ -171,6 +162,20 @@ export class HealthEstimate {
 				err
 			);
 		}
+	}
+
+	clearOverlay(token) {
+		const estimate = this._cache[token.document.id];
+		if (estimate && !estimate.destroyed) {
+			estimate.parent?.removeChild(estimate);
+			estimate.destroy();
+			delete this._cache[token.document.id];
+		}
+		this._handleOverlay(token, this.showCondition(token.hover));
+	}
+
+	clearOverlays() {
+		canvas.tokens?.placeables.forEach((token) => this.clearOverlay(token));
 	}
 
 	/**
@@ -338,10 +343,11 @@ export class HealthEstimate {
 		};
 
 		for (const [iteration, estimation] of this.estimations.entries()) {
-			if (!estimation.actorTypes.size && (estimation.rule === "default" || estimation.rule === "")) continue;
-			if (estimation.actorTypes.size && !estimation.actorTypes.has(token.actor.type)) continue;
-			if (validateEstimation(iteration, token, estimation)) {
-				if (estimation.ignoreColor) {
+			const { actorTypes, ignoreColor, rule } = estimation;
+			if (!actorTypes.size && ["default", ""].includes(rule)) continue;
+			if (actorTypes.size && !actorTypes.has(token.actor.type)) continue;
+			if ((actorTypes.has(token.actor.type) && !rule) || validateEstimation(iteration, token, estimation)) {
+				if (ignoreColor) {
 					special = estimation;
 				} else {
 					return {
@@ -508,53 +514,16 @@ export class HealthEstimate {
 	}
 
 	/**
-	 * Updates the Break Conditions and the Overlay Render's Break Condition method.
-	 * @returns {Boolean}
-	 */
-	updateBreakConditions() {
-		this.breakConditions.onlyGM = sGet("core.showDescription") === 1 ? "|| !game.user.isGM" : "";
-		this.breakConditions.onlyNotGM = sGet("core.showDescription") === 2 ? "|| game.user.isGM" : "";
-		this.breakConditions.onlyPCs =
-			sGet("core.showDescriptionTokenType") === 1 ? "|| !token.actor?.hasPlayerOwner" : "";
-		this.breakConditions.onlyNPCs =
-			sGet("core.showDescriptionTokenType") === 2 ? "|| token.actor?.hasPlayerOwner" : "";
-
-		const prep = (key) => (isEmpty(this.breakConditions[key]) ? "" : this.breakConditions[key]);
-
-		this.breakOverlayRender = (token) => {
-			try {
-				// eslint-disable-next-line no-new-func
-				return new Function(
-					"token",
-					`return (
-						false
-						${prep("onlyGM")}
-						${prep("onlyNotGM")}
-						${prep("onlyNPCs")}
-						${prep("onlyPCs")}
-						${prep("system")}
-					)`
-				)(token);
-			} catch(err) {
-				if (err.name === "TypeError") {
-					console.warn(
-						`Health Estimate | Error on breakOverlayRender(), skipping. Token Name: "${token.name}". Type: "${token.document.actor.type}".`,
-						err
-					);
-					return true;
-				}
-				console.error(err);
-			}
-		};
-	}
-
-	/**
 	 * Variables for settings to avoid multiple system calls for them, since the estimate can be called really often.
 	 * Updates the variables if any setting was changed.
 	 */
 	updateSettings() {
 		this.settings = {
 			display: sGet("display"),
+			showDescription: sGet("core.showDescription"),
+			showDescriptionTokenType: sGet("core.showDescriptionTokenType"),
+			breakOnZeroMaxHP: sGet("core.breakOnZeroMaxHP"),
+			hideVehicleHP: sGet("core.hideVehicleHP"),
 		};
 
 		this.descriptions = sGet("core.stateNames").split(/[,;]\s*/);

--- a/src/module/providers/CoC7.js
+++ b/src/module/providers/CoC7.js
@@ -1,13 +1,11 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class CoC7EstimationProvider extends EstimationProvider {
+	filteredTypes = ["container"];
+
 	fraction(token) {
 		const hp = token.actor.system.attribs.hp;
 		if (hp.max > 0) return hp.value / hp.max;
 		return 0;
-	}
-
-	get breakCondition() {
-		return "|| token.actor.type === 'container'";
 	}
 }

--- a/src/module/providers/D35E.js
+++ b/src/module/providers/D35E.js
@@ -2,39 +2,39 @@ import { f, sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class D35EEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.customLogic = `
+	customLogic = `
 		const hp = token.actor.system.attributes.hp;
 		let addTemp = 0;
 		if (game.settings.get("healthEstimate", "core.addTemp")) {
 			addTemp = hp.temp;
 		}
 		const totalHp = hp.value + addTemp;`;
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: game.i18n.localize("D35E.Disabled"),
-				ignoreColor: true,
-				rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && (totalHp === 0 || Array.from(token.actor.effects.values()).some((x) => x.name === game.i18n.localize(\"D35E.Disabled\")))",
-				estimates: [{ value: 100, label: game.i18n.localize("D35E.Disabled") }],
-			},
-			{
-				name: game.i18n.localize("D35E.Staggered"),
-				ignoreColor: true,
-				rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && (hp.nonlethal > 0 && totalHp == hp.nonlethal) || Array.from(token.actor.effects.values()).some((x) => x.name === game.i18n.localize(\"D35E.Staggered\"))",
-				estimates: [{ value: 100, label: game.i18n.localize("D35E.Staggered") }],
-			},
-			{
-				name: game.i18n.localize("D35E.Unconscious"),
-				ignoreColor: true,
-				rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && (hp.nonlethal > totalHp || Array.from(token.actor.effects.values()).some((x) => x.name === game.i18n.localize(\"D35E.Unconscious\")))",
-				estimates: [{ value: 100, label: game.i18n.localize("D35E.Unconscious") }],
-			},
-		];
-	}
+
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: game.i18n.localize("D35E.Disabled"),
+			ignoreColor: true,
+			rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && (totalHp === 0 || Array.from(token.actor.effects.values()).some((x) => x.name === game.i18n.localize(\"D35E.Disabled\")))",
+			estimates: [{ value: 100, label: game.i18n.localize("D35E.Disabled") }],
+		},
+		{
+			name: game.i18n.localize("D35E.Staggered"),
+			ignoreColor: true,
+			rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && (hp.nonlethal > 0 && totalHp == hp.nonlethal) || Array.from(token.actor.effects.values()).some((x) => x.name === game.i18n.localize(\"D35E.Staggered\"))",
+			estimates: [{ value: 100, label: game.i18n.localize("D35E.Staggered") }],
+		},
+		{
+			name: game.i18n.localize("D35E.Unconscious"),
+			ignoreColor: true,
+			rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && (hp.nonlethal > totalHp || Array.from(token.actor.effects.values()).some((x) => x.name === game.i18n.localize(\"D35E.Unconscious\")))",
+			estimates: [{ value: 100, label: game.i18n.localize("D35E.Unconscious") }],
+		},
+	];
 
 	fraction(token) {
 		const hp = token.actor.system.attributes.hp;

--- a/src/module/providers/age-system.js
+++ b/src/module/providers/age-system.js
@@ -1,10 +1,7 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class ageSystemEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.breakOnZeroMaxHP = "zero";
-	}
+	breakOnZeroMaxHP = "zero";
 
 	_breakAttribute = "token.actor.system.health";
 

--- a/src/module/providers/age-system.js
+++ b/src/module/providers/age-system.js
@@ -3,7 +3,9 @@ import EstimationProvider from "./templates/Base.js";
 export default class ageSystemEstimationProvider extends EstimationProvider {
 	breakOnZeroMaxHP = "zero";
 
-	_breakAttribute = "token.actor.system.health";
+	breakAttribute(token) {
+		return token.actor.system.health;
+	}
 
 	fraction(token) {
 		const hp = token.actor.system.health;

--- a/src/module/providers/alienrpg.js
+++ b/src/module/providers/alienrpg.js
@@ -38,14 +38,9 @@ export default class alienrpgEstimationProvider extends EstimationProvider {
 		return hp.value / hp.max;
 	}
 
-	get breakCondition() {
-		return `
-		|| ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-		|| (game.settings.get('healthEstimate', 'core.breakOnZeroMaxHP')
-			&& (
-				(${this.isVehicle} && token.actor.system.attributes.hull.max === 0)
-				|| (!${this.isVehicle} && token.actor.system.header.health.max === 0)
-			)
-		)`;
+	breakAttribute(token) {
+		return this.isVehicle(token)
+			? token.actor.system.attributes.hull.max
+			: token.actor.system.header.health.max;
 	}
 }

--- a/src/module/providers/alienrpg.js
+++ b/src/module/providers/alienrpg.js
@@ -2,29 +2,28 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class alienrpgEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules = {
-			config: true,
-			vehicles: ["vehicles", "spacecraft"],
-		};
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles & Spaceships",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle", "spacecraft"]
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles & Spaceships",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle", "spacecraft"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicles", "spacecraft"],
+	};
 
 	fraction(token) {
 		if (token.actor.type === "vehicles") {

--- a/src/module/providers/archmage.js
+++ b/src/module/providers/archmage.js
@@ -2,11 +2,9 @@ import { sGet } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class archmageEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
 
 	fraction(token) {
 		const hp = token.actor.system.attributes.hp;

--- a/src/module/providers/band-of-blades.js
+++ b/src/module/providers/band-of-blades.js
@@ -2,6 +2,8 @@ import { isEmpty } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class bandOfBladesEstimationProvider extends EstimationProvider {
+	filteredTypes = ["role", "chosen", "minion", "\uD83D\uDD5B clock"];
+
 	fraction(token) {
 		const hp = token.actor.system.harm;
 		let harmLevel = 0;
@@ -26,13 +28,5 @@ export default class bandOfBladesEstimationProvider extends EstimationProvider {
 			}
 		}
 		return 1 - (harmLevel / 18);
-	}
-
-	get breakCondition() {
-		return `
-		|| token.actor.type === "role"
-		|| token.actor.type === "chosen"
-		|| token.actor.type === "minion"
-		|| token.actor.type === "\uD83D\uDD5B clock"`;
 	}
 }

--- a/src/module/providers/blades-in-the-dark.js
+++ b/src/module/providers/blades-in-the-dark.js
@@ -2,6 +2,8 @@ import { isEmpty } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class bladesInTheDarkEstimationProvider extends EstimationProvider {
+	filteredTypes = ["npc", "crew", "factions", "\uD83D\uDD5B clock"];
+
 	fraction(token) {
 		const hp = token.actor.system.harm;
 		let harmLevel = 0;
@@ -26,13 +28,5 @@ export default class bladesInTheDarkEstimationProvider extends EstimationProvide
 			}
 		}
 		return 1 - (harmLevel / 18);
-	}
-
-	get breakCondition() {
-		return `
-		|| token.actor.type === "npc"
-		|| token.actor.type === "crew"
-		|| token.actor.type === "\uD83D\uDD5B clock"
-		|| token.actor.type === "factions"`;
 	}
 }

--- a/src/module/providers/crucible.js
+++ b/src/module/providers/crucible.js
@@ -16,31 +16,29 @@ function poolFraction(active, reserve, usesReserveResources) {
 }
 
 export default class crucibleEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		// Only Heroes and Adversaries track Health/Wounds & Morale/Madness. Group actors have no resources at all.
-		this.organicTypes = ["hero", "adversary"];
-		this.breakOnZeroMaxHP = "zero";
+	breakOnZeroMaxHP = "zero";
 
-		this.estimations = [
-			...this.estimations,
-			{
-				// Overrides the label (but not the color) whenever the Actor has gone Insane, since Madness
-				// filling up is just as incapacitating as Health/Wounds running out, but uses a separate pool.
-				name: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Insane"),
-				ignoreColor: true,
-				rule: "system.isInsane",
-				estimates: [{ value: 100, label: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Insane") }],
-			},
-			{
-				// Same idea for Broken (Morale at 0), unless the Actor is already Insane.
-				name: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Broken"),
-				ignoreColor: true,
-				rule: "system.isBroken && !system.isInsane",
-				estimates: [{ value: 100, label: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Broken") }],
-			},
-		];
-	}
+	estimations = [
+		...this.estimations,
+		{
+			// Overrides the label (but not the color) whenever the Actor has gone Insane, since Madness
+			// filling up is just as incapacitating as Health/Wounds running out, but uses a separate pool.
+			name: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Insane"),
+			ignoreColor: true,
+			rule: "system.isInsane",
+			estimates: [{ value: 100, label: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Insane") }],
+		},
+		{
+			// Same idea for Broken (Morale at 0), unless the Actor is already Insane.
+			name: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Broken"),
+			ignoreColor: true,
+			rule: "system.isBroken && !system.isInsane",
+			estimates: [{ value: 100, label: game.i18n.localize("ACTIVE_EFFECT.STATUSES.Broken") }],
+		},
+	];
+
+	// Only Heroes and Adversaries track Health/Wounds & Morale/Madness. Group actors have no resources at all.
+	organicTypes = ["hero", "adversary"];
 
 	_breakAttribute = "token.actor.system.resources.health.max";
 

--- a/src/module/providers/crucible.js
+++ b/src/module/providers/crucible.js
@@ -37,10 +37,14 @@ export default class crucibleEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["group"];
+
 	// Only Heroes and Adversaries track Health/Wounds & Morale/Madness. Group actors have no resources at all.
 	organicTypes = ["hero", "adversary"];
 
-	_breakAttribute = "token.actor.system.resources.health.max";
+	breakAttribute(token) {
+		return token.actor.system.resources.health.max;
+	}
 
 	/**
 	 * Combines Health and Wounds into a single smooth fraction. Health depletes first, then further damage
@@ -50,11 +54,5 @@ export default class crucibleEstimationProvider extends EstimationProvider {
 	fraction(token) {
 		const { resources, usesReserveResources } = token.actor.system;
 		return poolFraction(resources.health, resources.wounds, usesReserveResources);
-	}
-
-	get breakCondition() {
-		return `
-		|| token.actor.type === "group"
-		${super.breakCondition}`;
 	}
 }

--- a/src/module/providers/cyberpunk-red-core.js
+++ b/src/module/providers/cyberpunk-red-core.js
@@ -6,30 +6,27 @@ export default class cyberpunkRedCoreEstimationProvider extends EstimationProvid
 	// The issue is that this data is only broadcast to GMs, not other users.
 	// See https://github.com/mclemente/healthEstimate/issues/119
 	// and https://gitlab.com/cyberpunk-red-team/fvtt-cyberpunk-red-core/-/issues/680
-	constructor() {
-		super();
-		this.estimations = [
-			{
-				estimates: [
-					{ value: 0, label: game.i18n.localize("CPR.global.woundState.dead") },
-					{ value: 1, label: game.i18n.localize("CPR.global.woundState.mortallyWounded") },
-					{ value: 50, label: game.i18n.localize("CPR.global.woundState.seriouslyWounded") },
-					{ value: 99, label: game.i18n.localize("CPR.global.woundState.lightlyWounded") },
-					{ value: 100, label: game.i18n.localize("CPR.global.woundState.notWounded") },
-				],
-			},
-			{
-				name: `${game.i18n.localize("TYPES.Actor.Blackice")}/${game.i18n.localize("TYPES.Actor.Demon")}`,
-				estimates: [
-					{ value: 0, label: t("cyberpunk-red-core.unorganics.0") },
-					{ value: 50, label: t("cyberpunk-red-core.unorganics.2") },
-					{ value: 99, label: t("cyberpunk-red-core.unorganics.3") },
-					{ value: 100, label: t("cyberpunk-red-core.unorganics.4") },
-				],
-				actorTypes: ["blackIce", "demon"]
-			},
-		];
-	}
+	estimations = [
+		{
+			estimates: [
+				{ value: 0, label: game.i18n.localize("CPR.global.woundState.dead") },
+				{ value: 1, label: game.i18n.localize("CPR.global.woundState.mortallyWounded") },
+				{ value: 50, label: game.i18n.localize("CPR.global.woundState.seriouslyWounded") },
+				{ value: 99, label: game.i18n.localize("CPR.global.woundState.lightlyWounded") },
+				{ value: 100, label: game.i18n.localize("CPR.global.woundState.notWounded") },
+			],
+		},
+		{
+			name: `${game.i18n.localize("TYPES.Actor.Blackice")}/${game.i18n.localize("TYPES.Actor.Demon")}`,
+			estimates: [
+				{ value: 0, label: t("cyberpunk-red-core.unorganics.0") },
+				{ value: 50, label: t("cyberpunk-red-core.unorganics.2") },
+				{ value: 99, label: t("cyberpunk-red-core.unorganics.3") },
+				{ value: 100, label: t("cyberpunk-red-core.unorganics.4") },
+			],
+			actorTypes: ["blackIce", "demon"]
+		},
+	];
 
 	fraction(token) {
 		let hp;

--- a/src/module/providers/cyberpunk-red-core.js
+++ b/src/module/providers/cyberpunk-red-core.js
@@ -28,6 +28,8 @@ export default class cyberpunkRedCoreEstimationProvider extends EstimationProvid
 		},
 	];
 
+	filteredTypes = ["container"];
+
 	fraction(token) {
 		let hp;
 		if (token.actor.system.derivedStats) {
@@ -36,9 +38,5 @@ export default class cyberpunkRedCoreEstimationProvider extends EstimationProvid
 			hp = token.actor.system.stats.rez;
 		}
 		return hp.value / hp.max;
-	}
-
-	get breakCondition() {
-		return "|| token.actor.type === 'container'";
 	}
 }

--- a/src/module/providers/cyphersystem.js
+++ b/src/module/providers/cyphersystem.js
@@ -2,6 +2,8 @@ import { sGet } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class cyphersystemEstimationProvider extends EstimationProvider {
+	filteredTypes = ["marker"];
+
 	fraction(token) {
 		const actor = token.actor;
 		if (actor.type === "pc") {
@@ -41,9 +43,5 @@ export default class cyphersystemEstimationProvider extends EstimationProvider {
 				default: 0.1,
 			},
 		};
-	}
-
-	get breakCondition() {
-		return "|| ![ 'pc', 'npc', 'companion','community' ].includes(token.actor.type)";
 	}
 }

--- a/src/module/providers/daggerheart.js
+++ b/src/module/providers/daggerheart.js
@@ -1,39 +1,38 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class daggerheartEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.organicTypes = ["character", "adversary", "companion"];
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "unconscious",
-				rule: "effects.values().some((ef) => ef.statuses.has('unconscious'));",
-				estimates: [{ value: 100, label: game.i18n.localize("EFFECT.StatusUnconscious") }],
-			},
-			{
-				name: "dead",
-				ignoreColor: true,
-				rule: `
-					const { unconscious, defeated, dead } = CONFIG.DH.GENERAL.conditions;
-					const defeatedConditions = new Set([unconscious.id, defeated.id, dead.id]);
-					return actor?.statuses.intersection(defeatedConditions)?.size;`.trim(),
-				estimates: [{ value: 100, label: "Dead" }],
-			},
-			{
-				name: "companion",
-				estimates: [
-					{ value: 0, label: "Fleeing" },
-					{ value: 25, label: "Frightened" },
-					{ value: 50, label: "Exhausted" },
-					{ value: 99, label: "Winded" },
-					{ value: 100, label: "Energetic" },
-				],
-				actorTypes: ["companion"]
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "unconscious",
+			rule: "effects.values().some((ef) => ef.statuses.has('unconscious'));",
+			estimates: [{ value: 100, label: game.i18n.localize("EFFECT.StatusUnconscious") }],
+		},
+		{
+			name: "dead",
+			ignoreColor: true,
+			rule: `
+				const { unconscious, defeated, dead } = CONFIG.DH.GENERAL.conditions;
+				const defeatedConditions = new Set([unconscious.id, defeated.id, dead.id]);
+				return actor?.statuses.intersection(defeatedConditions)?.size;`.trim(),
+			estimates: [{ value: 100, label: "Dead" }],
+		},
+		{
+			name: "companion",
+			estimates: [
+				{ value: 0, label: "Fleeing" },
+				{ value: 25, label: "Frightened" },
+				{ value: 50, label: "Exhausted" },
+				{ value: 99, label: "Winded" },
+				{ value: 100, label: "Energetic" },
+			],
+			actorTypes: ["companion"]
+		},
+	];
+
+	organicTypes = ["character", "adversary", "companion"];
 
 	fraction(token) {
 		let resource = token.actor.type === "adversary" || token.actor.type === "character"

--- a/src/module/providers/daggerheart.js
+++ b/src/module/providers/daggerheart.js
@@ -3,6 +3,10 @@ import EstimationProvider from "./templates/Base.js";
 export default class daggerheartEstimationProvider extends EstimationProvider {
 	breakOnZeroMaxHP = "zero";
 
+	customLogic = `
+		const { unconscious, defeated, dead } = CONFIG.DH.GENERAL.conditions();
+		const defeatedConditions = new Set([unconscious.id, defeated.id, dead.id]);`;
+
 	estimations = [
 		...this.estimations,
 		{
@@ -13,10 +17,7 @@ export default class daggerheartEstimationProvider extends EstimationProvider {
 		{
 			name: _loc("DAGGERHEART.CONFIG.Condition.dead.name"),
 			ignoreColor: true,
-			rule: `
-				const { unconscious, defeated, dead } = CONFIG.DH.GENERAL.conditions;
-				const defeatedConditions = new Set([unconscious.id, defeated.id, dead.id]);
-				return actor?.statuses.intersection(defeatedConditions)?.size;`.trim(),
+			rule: "actor?.statuses.intersection(defeatedConditions)?.size;",
 			estimates: [{ value: 100, label: "Dead" }],
 		},
 		{

--- a/src/module/providers/dnd4e.js
+++ b/src/module/providers/dnd4e.js
@@ -2,12 +2,11 @@ import { sGet } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class dnd4eEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.organicTypes = ["Player Character", "NPC"];
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	organicTypes = ["Player Character", "NPC"];
 
 	fraction(token) {
 		const hp = token.actor.system.attributes.hp;

--- a/src/module/providers/dnd5e.js
+++ b/src/module/providers/dnd5e.js
@@ -22,6 +22,8 @@ export default class dnd5eEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["group"];
+
 	vehicleRules = {
 		config: true,
 		vehicles: ["vehicle"],
@@ -35,11 +37,7 @@ export default class dnd5eEstimationProvider extends EstimationProvider {
 		return Math.min(hp.value / hp.effectiveMax, 1);
 	}
 
-	get breakCondition() {
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-		|| token.actor.type == 'group'
-		|| ${this._breakAttribute} === null
-		${super.breakCondition}`;
+	breakCondition(token) {
+		return super.breakCondition(token) || this.breakAttribute(token) === null;
 	}
 }

--- a/src/module/providers/dnd5e.js
+++ b/src/module/providers/dnd5e.js
@@ -2,30 +2,30 @@ import { sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class dnd5eEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules = {
-			config: true,
-			vehicles: ["vehicle"],
-		};
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle"]
-			},
-		];
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle"],
+	};
 
 	fraction(token) {
 		const hp = token.actor.system.attributes.hp;

--- a/src/module/providers/draw-steel.js
+++ b/src/module/providers/draw-steel.js
@@ -2,52 +2,55 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class drawsteelEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.organicTypes = ["hero", "npc"];
-		this.breakOnZeroMaxHP = "zero";
-		this.vehicleRules.vehicles = ["object"];
-		this.estimations = [
-			{
-				estimates: [
-					{ value: 0, label: t("core.estimates.states.0") },
-					{ value: 33, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Dying") },
-					{ value: 66, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Winded") },
-					{ value: 99, label: t("core.estimates.states.4") },
-					{ value: 100, label: t("core.estimates.states.5") },
-				],
-			},
-			{
-				name: "NPCs",
-				estimates: [
-					{ value: 0, label: t("core.estimates.states.0") },
-					{ value: 25, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Dying") },
-					{ value: 50, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Winded") },
-					{ value: 99, label: t("core.estimates.states.4") },
-					{ value: 100, label: t("core.estimates.states.5") },
-				],
-				actorTypes: ["npc"]
-			},
-			{
-				name: "Objects",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["object"]
-			},
-			{
-				name: "Unconscious",
-				ignoreColor: true,
-				rule: "effects.values().some((ef) => ef.statuses.has('sleep'));",
-				estimates: [{ value: 100, label: game.i18n.localize("EFFECT.StatusUnconscious") }],
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		{
+			estimates: [
+				{ value: 0, label: t("core.estimates.states.0") },
+				{ value: 33, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Dying") },
+				{ value: 66, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Winded") },
+				{ value: 99, label: t("core.estimates.states.4") },
+				{ value: 100, label: t("core.estimates.states.5") },
+			],
+		},
+		{
+			name: "NPCs",
+			estimates: [
+				{ value: 0, label: t("core.estimates.states.0") },
+				{ value: 25, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Dying") },
+				{ value: 50, label: game.i18n.localize("DRAW_STEEL.ActiveEffect.StaminaEffects.Winded") },
+				{ value: 99, label: t("core.estimates.states.4") },
+				{ value: 100, label: t("core.estimates.states.5") },
+			],
+			actorTypes: ["npc"]
+		},
+		{
+			name: "Objects",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["object"]
+		},
+		{
+			name: "Unconscious",
+			ignoreColor: true,
+			rule: "effects.values().some((ef) => ef.statuses.has('sleep'));",
+			estimates: [{ value: 100, label: game.i18n.localize("EFFECT.StatusUnconscious") }],
+		},
+	];
+
+	organicTypes = ["hero", "npc"];
+
+	vehicleRules = {
+		config: false,
+		vehicles: ["object"],
+	};
 
 	_breakAttribute = "token.actor.system.stamina.max";
 

--- a/src/module/providers/draw-steel.js
+++ b/src/module/providers/draw-steel.js
@@ -52,8 +52,6 @@ export default class drawsteelEstimationProvider extends EstimationProvider {
 		vehicles: ["object"],
 	};
 
-	_breakAttribute = "token.actor.system.stamina.max";
-
 	fraction(token) {
 		const stamina = token.actor.system.stamina;
 		return (stamina.value - stamina.min) / (stamina.max - stamina.min);
@@ -68,9 +66,11 @@ export default class drawsteelEstimationProvider extends EstimationProvider {
 		};
 	}
 
-	get breakCondition() {
-		return `|| ${this.isVehicle} && game.settings.get('healthEstimate', 'draw-steel.hideObjectHP')
-		|| ${this._breakAttribute} === null
-		${super.breakCondition}`;
+	breakCondition(token) {
+		return super.breakCondition(token) || this.breakAttribute(token) === null;
+	}
+
+	breakAttribute(token) {
+		return token.actor.system.stamina.max;
 	}
 }

--- a/src/module/providers/dungeonworld.js
+++ b/src/module/providers/dungeonworld.js
@@ -1,10 +1,7 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class dungeonworldEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.breakOnZeroMaxHP = "zero";
-	}
+	breakOnZeroMaxHP = "zero";
 
 	fraction(token) {
 		const hp = token.actor.system.attributes.hp;

--- a/src/module/providers/forbidden-lands.js
+++ b/src/module/providers/forbidden-lands.js
@@ -1,10 +1,7 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class forbiddenLandsEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.breakOnZeroMaxHP = "zero";
-	}
+	breakOnZeroMaxHP = "zero";
 
 	_breakAttribute = "token.actor.system.attribute.strength.max";
 

--- a/src/module/providers/forbidden-lands.js
+++ b/src/module/providers/forbidden-lands.js
@@ -3,7 +3,7 @@ import EstimationProvider from "./templates/Base.js";
 export default class forbiddenLandsEstimationProvider extends EstimationProvider {
 	breakOnZeroMaxHP = "zero";
 
-	_breakAttribute = "token.actor.system.attribute.strength.max";
+	filteredTypes = ["party", "stronghold"];
 
 	fraction(token) {
 		switch (token.actor.type) {
@@ -17,10 +17,7 @@ export default class forbiddenLandsEstimationProvider extends EstimationProvider
 		}
 	}
 
-	get breakCondition() {
-		return `
-        || token.actor.type === "party"
-        || token.actor.type === "stronghold"
-        ${super.breakCondition}`;
+	breakAttribute(token) {
+		return token.actor.system.attribute.strength.max;
 	}
 }

--- a/src/module/providers/foundryvtt-reve-de-dragon.js
+++ b/src/module/providers/foundryvtt-reve-de-dragon.js
@@ -1,6 +1,8 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class reveDeDragonEstimationProvider extends EstimationProvider {
+	filteredTypes = ["vehicule"];
+
 	fraction(token) {
 		function ratio(node) {
 			return Math.clamped(node.value / node.max, 0, 1);
@@ -53,9 +55,5 @@ export default class reveDeDragonEstimationProvider extends EstimationProvider {
 		const ratioBlessure = 1 - ratio(estimationBlessures(token));
 
 		return Math.min(ratioBlessure, ratioEndurance, ratioFatigue, ratioVie);
-	}
-
-	get breakCondition() {
-		return "||token.actor.type === \"vehicule\"";
 	}
 }

--- a/src/module/providers/lancer.js
+++ b/src/module/providers/lancer.js
@@ -1,10 +1,7 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class lancerEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.breakOnZeroMaxHP = "zero";
-	}
+	breakOnZeroMaxHP = "zero";
 
 	_breakAttribute = "token.actor.system?.hp?.max";
 

--- a/src/module/providers/lancer.js
+++ b/src/module/providers/lancer.js
@@ -3,10 +3,12 @@ import EstimationProvider from "./templates/Base.js";
 export default class lancerEstimationProvider extends EstimationProvider {
 	breakOnZeroMaxHP = "zero";
 
-	_breakAttribute = "token.actor.system?.hp?.max";
-
 	fraction(token) {
 		const hp = token.actor.system.hp;
 		return hp.value / hp.max;
+	}
+
+	breakAttribute(token) {
+		return token.actor.system?.hp?.max;
 	}
 }

--- a/src/module/providers/monsterweek.js
+++ b/src/module/providers/monsterweek.js
@@ -1,12 +1,10 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class monsterweekEstimationProvider extends EstimationProvider {
+	filteredTypes = ["location"];
+
 	fraction(token) {
 		const hp = token.actor.system.harm;
 		return hp.value / hp.max;
-	}
-
-	get breakCondition() {
-		return "||token.actor.type === \"location\"";
 	}
 }

--- a/src/module/providers/od6s.js
+++ b/src/module/providers/od6s.js
@@ -2,28 +2,26 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class od6sEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules = {
-			config: true,
-			vehicles: ["vehicle", "starship"],
-		};
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle", "starship"]
-			},
-		];
-	}
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle", "starship"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle", "starship"],
+	};
 
 	fraction(token) {
 		const type = token.actor.type;

--- a/src/module/providers/od6s.js
+++ b/src/module/providers/od6s.js
@@ -18,6 +18,8 @@ export default class od6sEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["container"];
+
 	vehicleRules = {
 		config: true,
 		vehicles: ["vehicle", "starship"],
@@ -58,11 +60,5 @@ export default class od6sEstimationProvider extends EstimationProvider {
 				return 1 - (od6sdamage / 5);
 			}
 		}
-	}
-
-	get breakCondition() {
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-		|| token.actor.type === "container"`;
 	}
 }

--- a/src/module/providers/pf1.js
+++ b/src/module/providers/pf1.js
@@ -2,37 +2,37 @@ import { f, sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class pf1EstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.customLogic = `
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	customLogic = `
 		const hp = token.actor.system.attributes.hp;
 		let addTemp = 0;
 		if (game.settings.get("healthEstimate", "core.addTemp")) {
 			addTemp = hp.temp;
 		}
 		const totalHp = hp.value + addTemp;`;
-		this.estimations = [
-			...this.estimations,
-			{
-				name: game.i18n.localize("PF1.CondStaggered"),
-				ignoreColor: true,
-				rule: `
-					game.settings.get("healthEstimate", "PF1.showExtra") &&
-					(totalHp === 0 ||
-						(hp.nonlethal > 0 && totalHp == hp.nonlethal) ||
-						Array.from(token.actor.effects.values()).some((x) => x.label === game.i18n.localize("PF1.CondStaggered")))`,
-				estimates: [{ value: 100, label: game.i18n.localize("PF1.CondStaggered") }],
-			},
-			{
-				name: t("PF1.dyingName.name"),
-				ignoreColor: true,
-				rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && hp.nonlethal > totalHp",
-				estimates: [{ value: 100, label: t("PF1.dyingName.default") }],
-			},
-		];
-	}
+
+	estimations = [
+		...this.estimations,
+		{
+			name: game.i18n.localize("PF1.CondStaggered"),
+			ignoreColor: true,
+			rule: `
+				game.settings.get("healthEstimate", "PF1.showExtra") &&
+				(totalHp === 0 ||
+					(hp.nonlethal > 0 && totalHp == hp.nonlethal) ||
+					Array.from(token.actor.effects.values()).some((x) => x.label === game.i18n.localize("PF1.CondStaggered")))`,
+			estimates: [{ value: 100, label: game.i18n.localize("PF1.CondStaggered") }],
+		},
+		{
+			name: t("PF1.dyingName.name"),
+			ignoreColor: true,
+			rule: "game.settings.get(\"healthEstimate\", \"PF1.showExtra\") && hp.nonlethal > totalHp",
+			estimates: [{ value: 100, label: t("PF1.dyingName.default") }],
+		},
+	];
 
 	fraction(token) {
 		const { variants } = game.settings.get("pf1", "healthConfig");

--- a/src/module/providers/pf2e.js
+++ b/src/module/providers/pf2e.js
@@ -2,26 +2,25 @@ import { sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class pf2eEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles & Hazards",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle", "hazard"]
-			},
-		];
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles & Hazards",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle", "hazard"]
+		},
+	];
 
 	fraction(token) {
 		const data = foundry.utils.deepClone(token.actor.system.attributes);

--- a/src/module/providers/pf2e.js
+++ b/src/module/providers/pf2e.js
@@ -22,6 +22,8 @@ export default class pf2eEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["loot", "party"];
+
 	fraction(token) {
 		const data = foundry.utils.deepClone(token.actor.system.attributes);
 		const hp = data.hp;
@@ -65,12 +67,9 @@ export default class pf2eEstimationProvider extends EstimationProvider {
 		};
 	}
 
-	get breakCondition() {
-		return `
-        || token.actor.type === 'vehicle' && game.settings.get('healthEstimate', 'PF2E.hideVehicleHP')
-        || token.actor.type === 'hazard' && game.settings.get('healthEstimate', 'PF2E.hideHazardHP')
-        || token.actor.type === 'loot'
-        || token.actor.type === 'party'
-        ${super.breakCondition}`;
+	breakCondition(token) {
+		return (token.actor.type === "vehicle" && game.settings.get("healthEstimate", "PF2E.hideVehicleHP"))
+			|| (token.actor.type === "hazard" && game.settings.get("healthEstimate", "PF2E.hideHazardHP"))
+			|| super.breakCondition(token);
 	}
 }

--- a/src/module/providers/scum-and-villainy.js
+++ b/src/module/providers/scum-and-villainy.js
@@ -2,6 +2,8 @@ import { isEmpty } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class scumAndVillainyEstimationProvider extends EstimationProvider {
+	filteredTypes = ["ship", "\uD83D\uDD5B clock", "universe"];
+
 	fraction(token) {
 		const hp = token.actor.system.harm;
 		let harmLevel = 0;
@@ -26,9 +28,5 @@ export default class scumAndVillainyEstimationProvider extends EstimationProvide
 			}
 		}
 		return 1 - (harmLevel / 18);
-	}
-
-	get breakCondition() {
-		return "||token.actor.type === \"ship\"||token.actor.type === \"\uD83D\uDD5B clock\"||token.actor.type === \"universe\"";
 	}
 }

--- a/src/module/providers/sfrpg.js
+++ b/src/module/providers/sfrpg.js
@@ -2,41 +2,42 @@ import { sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class sfrpgEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.organicTypes.push("npc2");
-		this.vehicleRules = {
-			config: true,
-			vehicles: ["starship", "vehicle"],
-		};
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicle Threshold",
-				rule: "game.settings.get(\"healthEstimate\", \"starfinder.useThreshold\")",
-				estimates: [
-					{ value: 0, label: t("core.estimates.thresholds.0") },
-					{ value: 50, label: t("core.estimates.thresholds.1") },
-					{ value: 100, label: t("core.estimates.thresholds.2") },
-				],
-				actorTypes: ["vehicle"]
-			},
-			{
-				name: "Vehicles, Starships & Drones",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["starship", "vehicle", "drone"]
-			},
-		];
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicle Threshold",
+			rule: "game.settings.get(\"healthEstimate\", \"starfinder.useThreshold\")",
+			estimates: [
+				{ value: 0, label: t("core.estimates.thresholds.0") },
+				{ value: 50, label: t("core.estimates.thresholds.1") },
+				{ value: 100, label: t("core.estimates.thresholds.2") },
+			],
+			actorTypes: ["vehicle"]
+		},
+		{
+			name: "Vehicles, Starships & Drones",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["starship", "vehicle", "drone"]
+		},
+	];
+
+	organicTypes = [...this.organicTypes, "npc2"];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["starship", "vehicle"],
+	};
 
 	fraction(token) {
 		const type = token.actor.type;

--- a/src/module/providers/sfrpg.js
+++ b/src/module/providers/sfrpg.js
@@ -34,6 +34,8 @@ export default class sfrpgEstimationProvider extends EstimationProvider {
 
 	organicTypes = [...this.organicTypes, "npc2"];
 
+	filteredTypes = ["hazard"];
+
 	vehicleRules = {
 		config: true,
 		vehicles: ["starship", "vehicle"],
@@ -78,12 +80,5 @@ export default class sfrpgEstimationProvider extends EstimationProvider {
 				default: false,
 			},
 		};
-	}
-
-	get breakCondition() {
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-        || token.actor.type === 'hazard'
-        ${super.breakCondition}`;
 	}
 }

--- a/src/module/providers/splittermond.js
+++ b/src/module/providers/splittermond.js
@@ -57,10 +57,12 @@ export default class splittermondEstimationProvider extends EstimationProvider {
 		},
 	];
 
-	_breakAttribute = "token.actor.system.health.max";
-
 	fraction(token) {
 		const hp = token.actor.system.health;
 		return hp.total.value / hp.max;
+	}
+
+	breakAttribute(token) {
+		return token.actor.system.health.max;
 	}
 }

--- a/src/module/providers/splittermond.js
+++ b/src/module/providers/splittermond.js
@@ -1,66 +1,61 @@
 import EstimationProvider from "./templates/Base.js";
 
-function l(key) {
-	return game.i18n.localize(`splittermond.woundMalusLevels.${key}`);
-}
-
 export default class splittermondEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.breakOnZeroMaxHP = "zero";
+	#labels = {
+		notinjured: game.i18n.localize("splittermond.woundMalusLevels.notinjured"),
+		battered: game.i18n.localize("splittermond.woundMalusLevels.battered"),
+		injured: game.i18n.localize("splittermond.woundMalusLevels.injured"),
+		badlyinjured: game.i18n.localize("splittermond.woundMalusLevels.badlyinjured"),
+		doomed: game.i18n.localize("splittermond.woundMalusLevels.doomed"),
+	};
 
-		const notinjured = l("notinjured");
-		const battered = l("battered");
-		const injured = l("injured");
-		const badlyinjured = l("badlyinjured");
-		const doomed = l("doomed");
+	breakOnZeroMaxHP = "zero";
 
-		// Splittermond Gesundheitsstufen (GRW p.172)
-		// nbrLevels is modified by NPC features: Schwächlich (3) and Zerbrechlich (1)
-		this.customLogic = "const _nbrLevels = system.health?.woundMalus?.levels?.length ?? 5;";
+	customLogic = "const _nbrLevels = system.health?.woundMalus?.levels?.length ?? 5;";
 
-		this.estimations = [
-			// Default: 5 Gesundheitsstufen (standard)
-			// Boundaries at 80/60/40/20% of max HP
-			{
-				name: "",
-				rule: "",
-				ignoreColor: false,
-				estimates: [
-					{ value: 0, label: doomed },
-					{ value: 19, label: doomed },
-					{ value: 39, label: badlyinjured },
-					{ value: 59, label: injured },
-					{ value: 79, label: battered },
-					{ value: 100, label: notinjured },
-				],
-			},
-			// Schwächlich: 3 Gesundheitsstufen
-			// Boundaries at 2/3 and 1/3 of max HP (trunc to 66% and 33%)
-			{
-				name: "Schwächlich (3 Gesundheitsstufen)",
-				rule: "_nbrLevels === 3",
-				ignoreColor: false,
-				estimates: [
-					{ value: 0, label: doomed },
-					{ value: 32, label: doomed },
-					{ value: 65, label: injured },
-					{ value: 100, label: notinjured },
-				],
-			},
-			// Zerbrechlich: 1 Gesundheitsstufe (no wound penalties)
-			{
-				name: "Zerbrechlich (1 Gesundheitsstufe)",
-				rule: "_nbrLevels === 1",
-				ignoreColor: false,
-				estimates: [
-					{ value: 0, label: doomed },
-					{ value: 50, label: battered },
-					{ value: 100, label: notinjured },
-				],
-			},
-		];
-	}
+	estimations = [
+		// Default: 5 Gesundheitsstufen (standard)
+		// Boundaries at 80/60/40/20% of max HP
+		{
+			name: "",
+			rule: "",
+			ignoreColor: false,
+			estimates: [
+				{ value: 0, label: this.#labels.doomed },
+				{ value: 19, label: this.#labels.doomed },
+				{ value: 39, label: this.#labels.badlyinjured },
+				{ value: 59, label: this.#labels.injured },
+				{ value: 79, label: this.#labels.battered },
+				{ value: 100, label: this.#labels.notinjured },
+			],
+		},
+
+		// Schwächlich: 3 Gesundheitsstufen
+		// Boundaries at 2/3 and 1/3 of max HP (trunc to 66% and 33%)
+		{
+			name: "Schwächlich (3 Gesundheitsstufen)",
+			rule: "_nbrLevels === 3",
+			ignoreColor: false,
+			estimates: [
+				{ value: 0, label: this.#labels.doomed },
+				{ value: 32, label: this.#labels.doomed },
+				{ value: 65, label: this.#labels.injured },
+				{ value: 100, label: this.#labels.notinjured },
+			],
+		},
+
+		// Zerbrechlich: 1 Gesundheitsstufe (no wound penalties)
+		{
+			name: "Zerbrechlich (1 Gesundheitsstufe)",
+			rule: "_nbrLevels === 1",
+			ignoreColor: false,
+			estimates: [
+				{ value: 0, label: this.#labels.doomed },
+				{ value: 50, label: this.#labels.battered },
+				{ value: 100, label: this.#labels.notinjured },
+			],
+		},
+	];
 
 	_breakAttribute = "token.actor.system.health.max";
 

--- a/src/module/providers/starwarsffg.js
+++ b/src/module/providers/starwarsffg.js
@@ -2,29 +2,28 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class starwarsffgEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules = {
-			config: true,
-			vehicles: ["vehicle"],
-		};
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle"]
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle"],
+	};
 
 	fraction(token) {
 		let hp = token.actor.system.stats.wounds;

--- a/src/module/providers/starwarsffg.js
+++ b/src/module/providers/starwarsffg.js
@@ -20,6 +20,8 @@ export default class starwarsffgEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["hazard"];
+
 	vehicleRules = {
 		config: true,
 		vehicles: ["vehicle"],
@@ -33,17 +35,9 @@ export default class starwarsffgEstimationProvider extends EstimationProvider {
 		return Math.min((hp.max - hp.value) / hp.max, 1);
 	}
 
-	get breakCondition() {
-		let str = "false";
-		if (!["false", "none"].includes(game.settings.get("healthEstimate", "core.breakOnZeroMaxHP"))) {
-			str = `
-				(token.actor.type === 'vehicle' && token.actor.system.stats.hullTrauma.max ${this.breakMaxHPValue})
-				|| (token.actor.type !== 'vehicle' && token.actor.system.stats.wounds.max ${this.breakMaxHPValue})
-			`;
-		}
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-        || token.actor.type === 'hazard'
-        || ${str}`;
+	breakAttribute(token) {
+		return this.isVehicle(token)
+			? token.actor.system.attributes.hullTrauma.max
+			: token.actor.system.stats.wounds.max;
 	}
 }

--- a/src/module/providers/swade.js
+++ b/src/module/providers/swade.js
@@ -59,8 +59,4 @@ export default class swadeEstimationProvider extends EstimationProvider {
 	tokenEffects(token) {
 		return !!token.actor.effects.find((e) => e.img === CONFIG.statusEffects.incapacitated.img);
 	}
-
-	get breakCondition() {
-		return `|| ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')`;
-	}
 }

--- a/src/module/providers/swade.js
+++ b/src/module/providers/swade.js
@@ -2,35 +2,36 @@ import { sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class swadeEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules.config = true;
-		this.deathStateName = game.i18n.localize("SWADE.Incap");
-		this.deathMarker.config = game.modules.get("condition-lab-triggler")?.active;
-		this.estimations = [
-			{
-				estimates: [
-					{ value: 0, label: game.i18n.localize("SWADE.Incap") },
-					{ value: 25, label: t("core.estimates.states.1") },
-					{ value: 50, label: t("core.estimates.states.2") },
-					{ value: 99, label: t("core.estimates.states.3") },
-					{ value: 100, label: t("core.estimates.states.5") },
-				],
-			},
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle"]
-			},
-		];
-	}
+	deathStateName = game.i18n.localize("SWADE.Incap");
+
+	estimations = [
+		{
+			estimates: [
+				{ value: 0, label: game.i18n.localize("SWADE.Incap") },
+				{ value: 25, label: t("core.estimates.states.1") },
+				{ value: 50, label: t("core.estimates.states.2") },
+				{ value: 99, label: t("core.estimates.states.3") },
+				{ value: 100, label: t("core.estimates.states.5") },
+			],
+		},
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle"],
+	};
 
 	fraction(token) {
 		const hp = token.actor.system.wounds;

--- a/src/module/providers/t2k4e.js
+++ b/src/module/providers/t2k4e.js
@@ -2,27 +2,30 @@ import { sGet, t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class t2k4eEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules.config = true;
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle"]
-			},
-		];
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle"],
+	};
 
 	fraction(token) {
 		const type = token.actor.type;

--- a/src/module/providers/t2k4e.js
+++ b/src/module/providers/t2k4e.js
@@ -22,6 +22,8 @@ export default class t2k4eEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["party", "unit"];
+
 	vehicleRules = {
 		config: true,
 		vehicles: ["vehicle"],
@@ -42,18 +44,9 @@ export default class t2k4eEstimationProvider extends EstimationProvider {
 		return Math.min((temp + hp.value) / hp.max, 1);
 	}
 
-	get breakCondition() {
-		let str = "false";
-		if (!["false", "none"].includes(game.settings.get("healthEstimate", "core.breakOnZeroMaxHP"))) {
-			str = `
-				(${this.isVehicle} && token.actor.system.reliability.max ${this.breakMaxHPValue})
-				|| (!${this.isVehicle} && token.actor.system.health.max ${this.breakMaxHPValue})
-			`;
-		}
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-		|| token.actor.type == "unit"
-		|| token.actor.type == "party"
-		|| ${str}`;
+	breakAttribute(token) {
+		return this.isVehicle(token)
+			? token.actor.system.reliability.max
+			: token.actor.system.health.max;
 	}
 }

--- a/src/module/providers/templates/Base.js
+++ b/src/module/providers/templates/Base.js
@@ -1,89 +1,84 @@
 import { t } from "../../utils.js";
 
 export default class EstimationProvider {
-	constructor() {
-		/**
-		 * Non-exhaustive list of possible character-types that should use the DeathStateName. This is way to avoid vehicles being "Dead"
-		 * @type {string[]}
-		 */
-		this.organicTypes = ["character", "pc", "monster", "mook", "npc", "familiar", "traveller", "animal"]; // There must be a better way
+	/**
+	 * Sets if the "Add Temporary Health" setting is enabled.
+	 * @type {Boolean}
+	 */
+	addTemp = false;
 
-		/**
-		 * Code that will be run during HealthEstimate.getTokenEstimate()
-		 * @type {string}
-		 */
-		this.customLogic = "";
+	/**
+	 * Sets the default value for the "Hide on tokens with 0 max HP" setting. Hidden if set to false.
+	 * @type {false|String}
+	 */
+	breakOnZeroMaxHP = false;
 
-		/**
-		 * Default value of the Death State setting.
-		 * @type {Boolean}
-		 * */
-		this.deathState = false;
+	/**
+	 * Code that will be run during HealthEstimate.getTokenEstimate()
+	 * @type {string}
+	 */
+	customLogic = "";
 
-		/**
-		 * Default value of the Death State Name setting.
-		 * @type {String}
-		 */
-		this.deathStateName = t("core.deathStateName.default");
+	/**
+	 * Default value of the Death State setting.
+	 * @type {Boolean}
+	 * */
+	deathState = false;
 
-		/**
-		 * Configuration for the Death Marker setting.
-		 * @type {Object}
-		 */
-		this.deathMarker = {
-			/** Sets if the setting will be visible in the module's settings */
-			config:
-				!CONFIG.statusEffects.dead
-				|| game.modules.get("combat-utility-belt")?.active
-				|| game.modules.get("condition-lab-triggler")?.active,
-			/** Sets the setting's default value */
-			default: CONFIG.statusEffects.dead?.img || "icons/svg/skull.svg",
-		};
+	/**
+	 * Default value of the Death State Name setting.
+	 * @type {String}
+	 */
+	deathStateName = t("core.deathStateName.default");
 
-		/**
-		 *
-		 * @type {Object}
-		 */
-		this.vehicleRules = {
-			/** Sets if the setting will be visible in the module's settings */
-			config: false,
-			/** List with actor types that are considered vehicles (e.g. spacecraft, drone, etc) */
-			vehicles: ["vehicle"],
-		};
+	/**
+	 * Configuration for the Death Marker setting.
+	 * @param {Boolean} config	Sets if the setting will be visible in the module's settings
+	 * @param {Boolean} default	Sets the setting's default value
+	 * @type {Object}
+	 */
+	deathMarker = {
+		config: !CONFIG.statusEffects.dead,
+		default: CONFIG.statusEffects.dead?.img || "icons/svg/skull.svg",
+	};
 
-		/**
-		 * Sets if the "Add Temporary Health" setting is enabled.
-		 * @type {Boolean}
-		 */
-		this.addTemp = false;
+	/**
+	 * Default value of the Estimations setting.
+	 * @type {{Array}}
+	 */
+	estimations = [
+		{
+			name: "",
+			ignoreColor: false,
+			rule: "",
+			estimates: [
+				{ value: 0, label: t("core.estimates.states.0") },
+				{ value: 25, label: t("core.estimates.states.1") },
+				{ value: 50, label: t("core.estimates.states.2") },
+				{ value: 75, label: t("core.estimates.states.3") },
+				{ value: 99, label: t("core.estimates.states.4") },
+				{ value: 100, label: t("core.estimates.states.5") },
+			],
+			actorTypes: []
+		},
+	];
 
-		/**
-		 * Sets the default value for the "Hide on tokens with 0 max HP" setting. Hidden if set to false.
-		 * @type {false|String}
-		 */
-		this.breakOnZeroMaxHP = false;
+	/**
+	 * Non-exhaustive list of possible character-types that should use the DeathStateName. This is way to avoid vehicles being "Dead"
+	 * @type {string[]}
+	 */
+	organicTypes = ["character", "pc", "monster", "mook", "npc", "familiar", "traveller", "animal"]; // There must be a better way
 
-		/**
-		 * Default value of the Estimations setting.
-		 * @type {{Array}}
-		 */
-		this.estimations = [
-			{
-				name: "",
-				ignoreColor: false,
-				rule: "",
-				estimates: [
-					{ value: 0, label: t("core.estimates.states.0") },
-					{ value: 25, label: t("core.estimates.states.1") },
-					{ value: 50, label: t("core.estimates.states.2") },
-					{ value: 75, label: t("core.estimates.states.3") },
-					{ value: 99, label: t("core.estimates.states.4") },
-					{ value: 100, label: t("core.estimates.states.5") },
-				],
-				actorTypes: []
-			},
-		];
-	}
+	/**
+	 *
+	 * @param {Boolean} config	Sets if the setting will be visible in the module's settings
+	 * @param {String[]} vehicles	List with actor types that are considered vehicles (e.g. spacecraft, drone, etc)
+	 * @type {Object}
+	 */
+	vehicleRules = {
+		config: false,
+		vehicles: ["vehicle"],
+	};
 
 	_breakAttribute = "token.actor.system.attributes.hp.max";
 

--- a/src/module/providers/templates/Base.js
+++ b/src/module/providers/templates/Base.js
@@ -64,7 +64,14 @@ export default class EstimationProvider {
 	];
 
 	/**
-	 * Non-exhaustive list of possible character-types that should use the DeathStateName. This is way to avoid vehicles being "Dead"
+	 * Actor types that are skipped.
+	 * @type {string[]}
+	 */
+	filteredTypes = [];
+
+	/**
+	 * Actor types that should use the DeathStateName.
+	 * This is to avoid vehicles being labeled as "Dead".
 	 * @type {string[]}
 	 */
 	organicTypes = ["character", "pc", "monster", "mook", "npc", "familiar", "traveller", "animal"]; // There must be a better way
@@ -79,8 +86,6 @@ export default class EstimationProvider {
 		config: false,
 		vehicles: ["vehicle"],
 	};
-
-	_breakAttribute = "token.actor.system.attributes.hp.max";
 
 	/**
 	 * Calculates the fraction of the current health divided by the maximum health.
@@ -120,37 +125,40 @@ export default class EstimationProvider {
 	 *
 	 * @see alienrpgEstimationProvider
 	 */
-	get isVehicle() {
-		return `['${this.vehicleRules.vehicles.join("','")}'].includes(token.actor.type)`;
+	isVehicle(token) {
+		return this.vehicleRules.vehicles.join("','").includes(token.actor.type);
 	}
 
 	/**
 	 * A set of conditionals written as a string that will stop the rendering of the estimate.
+	 * @param {Token} token
 	 * @returns {String}
 	 *
 	 * @see dnd5eEstimationProvider
 	 * @see pf2eEstimationProvider
 	 */
-	get breakCondition() {
-		const breakOnZeroMaxHP = game.settings.get("healthEstimate", "core.breakOnZeroMaxHP");
+	breakCondition(token) {
+		const breakOnZeroMaxHP = game.healthEstimate.settings.breakOnZeroMaxHP;
+
+		if (
+			this.vehicleRules.config
+			&& this.isVehicle(token)
+			&& game.healthEstimate.settings.hideVehicleHP
+		) return true;
+
 		// "false" was the original value of "none" for when the setting was a Boolean
 		if (this.breakOnZeroMaxHP && !["false", "none"].includes(breakOnZeroMaxHP)) {
-			return `|| ${this.breakAttribute} ${this.breakMaxHPValue}`;
+			// "true" was the original value of 0 for when the setting was a Boolean
+			if (breakOnZeroMaxHP === "zero" || breakOnZeroMaxHP === "true") return this.breakAttribute(token) === 0;
+			if (breakOnZeroMaxHP === "one") return this.breakAttribute(token) === 1;
+			if (breakOnZeroMaxHP === "zeroOrOne") return this.breakAttribute(token) <= 1;
 		}
-		return "|| false";
+
+		return false;
 	}
 
-	get breakAttribute() {
-		return this._breakAttribute;
-	}
-
-	// eslint-disable-next-line getter-return
-	get breakMaxHPValue() {
-		const breakOnZeroMaxHP = game.settings.get("healthEstimate", "core.breakOnZeroMaxHP");
-		// "true" was the original value of 0 for when the setting was a Boolean
-		if (breakOnZeroMaxHP === "zero" || breakOnZeroMaxHP === "true") return "=== 0";
-		if (breakOnZeroMaxHP === "one") return "=== 1";
-		if (breakOnZeroMaxHP === "zeroOrOne") return "<= 1";
+	breakAttribute(token) {
+		return token.actor?.system?.attributes?.hp?.max;
 	}
 
 	/**

--- a/src/module/providers/templates/Generic.js
+++ b/src/module/providers/templates/Generic.js
@@ -2,10 +2,7 @@ import { sGet, t } from "../../utils.js";
 import EstimationProvider from "./Base.js";
 
 export default class GenericEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-	}
+	addTemp = true;
 
 	fraction(token) {
 		const hpPath = sGet("core.custom.FractionHP");

--- a/src/module/providers/tormenta20.js
+++ b/src/module/providers/tormenta20.js
@@ -2,11 +2,9 @@ import { sGet } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class tormenta20EstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
 
 	_breakAttribute = "token.actor.system.attributes.pv.max";
 

--- a/src/module/providers/tormenta20.js
+++ b/src/module/providers/tormenta20.js
@@ -6,8 +6,6 @@ export default class tormenta20EstimationProvider extends EstimationProvider {
 
 	breakOnZeroMaxHP = "zero";
 
-	_breakAttribute = "token.actor.system.attributes.pv.max";
-
 	fraction(token) {
 		const hp = token.actor.system.attributes.pv;
 		let temp = 0;
@@ -15,5 +13,9 @@ export default class tormenta20EstimationProvider extends EstimationProvider {
 			temp = hp.temp;
 		}
 		return Math.min((temp + hp.value) / hp.max, 1);
+	}
+
+	breakAttribute(token) {
+		return token.actor.system.attributes.pv.max;
 	}
 }

--- a/src/module/providers/trpg.js
+++ b/src/module/providers/trpg.js
@@ -2,11 +2,9 @@ import { sGet } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class trpgEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
 
 	fraction(token) {
 		const hp = token.actor.system.attributes.hp;

--- a/src/module/providers/twodsix.js
+++ b/src/module/providers/twodsix.js
@@ -2,29 +2,28 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class twodsixEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules = {
-			config: true,
-			vehicles: ["vehicle", "ship"],
-		};
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle", "ship"]
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle", "ship"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle", "ship"],
+	};
 
 	fraction(token) {
 		switch (token.actor.type) {

--- a/src/module/providers/twodsix.js
+++ b/src/module/providers/twodsix.js
@@ -20,6 +20,8 @@ export default class twodsixEstimationProvider extends EstimationProvider {
 		},
 	];
 
+	filteredTypes = ["world"];
+
 	vehicleRules = {
 		config: true,
 		vehicles: ["vehicle", "ship"],
@@ -71,16 +73,9 @@ export default class twodsixEstimationProvider extends EstimationProvider {
 		}
 	}
 
-	get breakCondition() {
-		let str = "false";
-		if (!["false", "none"].includes(game.settings.get("healthEstimate", "core.breakOnZeroMaxHP"))) {
-			str = `
-			(token.actor.system?.hits?.max ${this.breakMaxHPValue}
-			|| token.actor.system?.shipStats?.hull.max${this.breakMaxHPValue})
-			|| token.actor.system?.count?.max ${this.breakMaxHPValue}`;
-		}
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-		|| token.actor.type !== "vehicle" && ${str}`;
+	breakAttribute(token) {
+		return token.actor.system?.hits?.max
+			?? token.actor.system?.shipStats?.hull.max
+			?? token.actor.system?.count?.max;
 	}
 }

--- a/src/module/providers/weirdwizard.js
+++ b/src/module/providers/weirdwizard.js
@@ -1,22 +1,20 @@
 import EstimationProvider from "./templates/Base.js";
 
 export default class weirdwizardEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.deathStateName = game.i18n.localize("WW.Health.Estimation.Dead");
-		this.estimations = [
-			{
-				estimates: [
-					{ value: 0, label: game.i18n.localize("WW.Health.Estimation.100") },
-					{ value: 25, label: game.i18n.localize("WW.Health.Estimation.75") },
-					{ value: 50, label: game.i18n.localize("WW.Health.Estimation.50") },
-					{ value: 75, label: game.i18n.localize("WW.Health.Estimation.25") },
-					{ value: 99.99, label: game.i18n.localize("WW.Health.Estimation.1") },
-					{ value: 100, label: game.i18n.localize("WW.Health.Estimation.0") }
-				],
-			},
-		];
-	}
+	deathStateName = game.i18n.localize("WW.Health.Estimation.Dead");
+
+	estimations = [
+		{
+			estimates: [
+				{ value: 0, label: game.i18n.localize("WW.Health.Estimation.100") },
+				{ value: 25, label: game.i18n.localize("WW.Health.Estimation.75") },
+				{ value: 50, label: game.i18n.localize("WW.Health.Estimation.50") },
+				{ value: 75, label: game.i18n.localize("WW.Health.Estimation.25") },
+				{ value: 99.99, label: game.i18n.localize("WW.Health.Estimation.1") },
+				{ value: 100, label: game.i18n.localize("WW.Health.Estimation.0") }
+			],
+		},
+	];
 
 	fraction(token) {
 		const hp = token.actor.system.stats.damage;

--- a/src/module/providers/wfrp4e.js
+++ b/src/module/providers/wfrp4e.js
@@ -25,16 +25,12 @@ export default class wfrp4eEstimationProvider extends EstimationProvider {
 		vehicles: ["vehicle"],
 	};
 
-	_breakAttribute = "token.actor.system.status.wounds";
-
 	fraction(token) {
 		const hp = token.actor.system.status.wounds;
 		return hp.value / hp.max;
 	}
 
-	get breakCondition() {
-		return `
-        || ${this.isVehicle} && game.settings.get('healthEstimate', 'core.hideVehicleHP')
-		${super.breakCondition}`;
+	breakAttribute(token) {
+		return token.actor.system.status.wounds;
 	}
 }

--- a/src/module/providers/wfrp4e.js
+++ b/src/module/providers/wfrp4e.js
@@ -2,26 +2,28 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class wfrp4eEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.vehicleRules.config = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Vehicles",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["vehicle"]
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Vehicles",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["vehicle"]
+		},
+	];
+
+	vehicleRules = {
+		config: true,
+		vehicles: ["vehicle"],
+	};
 
 	_breakAttribute = "token.actor.system.status.wounds";
 

--- a/src/module/providers/wrath-and-glory.js
+++ b/src/module/providers/wrath-and-glory.js
@@ -8,12 +8,14 @@ export default class wrathAndGloryEstimationProvider extends EstimationProvider 
 
 	organicTypes = ["agent", "threat"];
 
-	_breakAttribute = "token.actor.system.combat.wounds.max";
-
 	fraction(token) {
 		const hp = token.actor.system.combat.wounds;
 		let temp = 0;
 		if (sGet("core.addTemp")) temp = Number(hp.bonus);
 		return (Number(hp.max) + temp - Number(hp.value)) / (Number(hp.max) + temp);
+	}
+
+	breakAttribute(token) {
+		return token.actor.system.combat.wounds.max;
 	}
 }

--- a/src/module/providers/wrath-and-glory.js
+++ b/src/module/providers/wrath-and-glory.js
@@ -2,12 +2,11 @@ import { sGet } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class wrathAndGloryEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.addTemp = true;
-		this.breakOnZeroMaxHP = "zero";
-		this.organicTypes = ["agent", "threat"];
-	}
+	addTemp = true;
+
+	breakOnZeroMaxHP = "zero";
+
+	organicTypes = ["agent", "threat"];
 
 	_breakAttribute = "token.actor.system.combat.wounds.max";
 

--- a/src/module/providers/yzecoriolis.js
+++ b/src/module/providers/yzecoriolis.js
@@ -2,25 +2,23 @@ import { t } from "../utils.js";
 import EstimationProvider from "./templates/Base.js";
 
 export default class yzecoriolisEstimationProvider extends EstimationProvider {
-	constructor() {
-		super();
-		this.breakOnZeroMaxHP = "zero";
-		this.estimations = [
-			...this.estimations,
-			{
-				name: "Ships",
-				estimates: [
-					{ value: 0, label: t("core.estimates.vehicles.0") },
-					{ value: 20, label: t("core.estimates.vehicles.1") },
-					{ value: 40, label: t("core.estimates.vehicles.2") },
-					{ value: 60, label: t("core.estimates.vehicles.3") },
-					{ value: 80, label: t("core.estimates.vehicles.4") },
-					{ value: 100, label: t("core.estimates.vehicles.5") },
-				],
-				actorTypes: ["ship"]
-			},
-		];
-	}
+	breakOnZeroMaxHP = "zero";
+
+	estimations = [
+		...this.estimations,
+		{
+			name: "Ships",
+			estimates: [
+				{ value: 0, label: t("core.estimates.vehicles.0") },
+				{ value: 20, label: t("core.estimates.vehicles.1") },
+				{ value: 40, label: t("core.estimates.vehicles.2") },
+				{ value: 60, label: t("core.estimates.vehicles.3") },
+				{ value: 80, label: t("core.estimates.vehicles.4") },
+				{ value: 100, label: t("core.estimates.vehicles.5") },
+			],
+			actorTypes: ["ship"]
+		},
+	];
 
 	fraction(token) {
 		const type = token.actor.type;

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -42,16 +42,7 @@ export const registerSettings = function () {
 		},
 		onChange: (value) => {
 			game.healthEstimate.settings.display = value;
-			canvas.tokens?.placeables.forEach((token) => {
-				const estimate = game.healthEstimate._cache[token.document.id];
-				if (["nameplate", "disabled"].includes(value)) {
-					if (estimate && !estimate.destroyed) {
-						estimate.parent?.removeChild(estimate);
-						estimate.destroy();
-					}
-				}
-				game.healthEstimate._handleOverlay(token, game.healthEstimate.showCondition(token.hover));
-			});
+			if (["nameplate", "disabled"].includes(value)) game.healthEstimate.clearOverlays();
 		},
 	});
 	/* Settings for the main settings menu */
@@ -82,7 +73,7 @@ export const registerSettings = function () {
 				),
 				actorTypes: new SetField(new StringField({
 					choices: Object.fromEntries(CONFIG.Actor.documentClass.TYPES
-						.filter((t) => t !== "base")
+						.filter((t) => t !== "base" && !game.healthEstimate.provider.filteredTypes.includes(t))
 						.map((t) => {
 							let label = CONFIG.Actor.typeLabels[t];
 							label = label && game.i18n.has(label) ? _loc(label) : t;
@@ -133,8 +124,8 @@ export const registerSettings = function () {
 				one: "healthEstimate.core.breakOnZeroMaxHP.options.one",
 				zeroOrOne: "healthEstimate.core.breakOnZeroMaxHP.options.zeroOrOne"
 			}}),
-		onChange: () => {
-			game.healthEstimate.updateBreakConditions();
+		onChange: (value) => {
+			game.healthEstimate.settings.breakOnZeroMaxHP = value;
 		}
 	});
 	addSetting("core.hideVehicleHP", {
@@ -161,8 +152,10 @@ export const registerSettings = function () {
 			1: t("core.showDescription.choices.GM"),
 			2: t("core.showDescription.choices.Players"),
 		},
-		onChange: () => {
-			game.healthEstimate.updateBreakConditions();
+		onChange: (value) => {
+			game.healthEstimate.settings.showDescription = value;
+			if (!value) canvas.scene?.tokens.forEach((token) => token.object.refresh());
+			else if (game.user.isGM === (value === 2)) game.healthEstimate.clearOverlays();
 		},
 	});
 	addMenuSetting("core.showDescriptionTokenType", {
@@ -173,8 +166,10 @@ export const registerSettings = function () {
 			1: t("core.showDescription.choices.PC"),
 			2: t("core.showDescription.choices.NPC"),
 		},
-		onChange: () => {
-			game.healthEstimate.updateBreakConditions();
+		onChange: (value) => {
+			game.healthEstimate.settings.showDescriptionTokenType = value;
+			if (!value) canvas.scene?.tokens.forEach((token) => token.object.refresh());
+			else game.healthEstimate.clearOverlays();
 		},
 	});
 	addMenuSetting("core.deathState", {


### PR DESCRIPTION
- Moved Provider initilization out of its constructor, so subclasses don't need to set up its own constructor for the smallest changes.
- `EstimationProvider#breakAttribute`, `#breakCondition` and `#isVehicle` accessors are now proper functions that take a Token as parameter.
- Added `EstimationProvider.filteredTypes` array to list actor types to be filtered out by the provider. These types are also excluded from the `actorTypes` field from the Estimations setting.
- `HealthEstimate#breakOverlayRender` has been absorbed by `#_handleOverlay` and no longer generates a Function at runtime to handle break conditions.
- `HealthEstimate#clearOverlay` and `#clearOverlays` have been added as shortcuts to delete estimates.